### PR TITLE
fix: align pwned virtual text config keys

### DIFF
--- a/lua/camouflage/config.lua
+++ b/lua/camouflage/config.lua
@@ -77,6 +77,7 @@ local M = {}
 ---@field sign_text? string Sign icon (default: "!")
 ---@field sign_hl? string Sign highlight group (default: "DiagnosticWarn")
 ---@field virtual_text_format? string Virtual text format (default: "PWNED (%s)")
+---@field virtual_text_prefix? string Deprecated: prefix for virtual text, use virtual_text_format instead
 ---@field virtual_text_hl? string Virtual text highlight (default: "DiagnosticWarn")
 ---@field line_hl? string Line highlight group (default: "CamouflagePwned")
 

--- a/lua/camouflage/pwned/init.lua
+++ b/lua/camouflage/pwned/init.lua
@@ -73,6 +73,8 @@ local function get_ui_config()
     show_virtual_text = pwned_cfg.show_virtual_text,
     show_line_highlight = pwned_cfg.show_line_highlight,
     sign_text = pwned_cfg.sign_text,
+    virtual_text_format = pwned_cfg.virtual_text_format,
+    -- Backward compatibility for older configs/tests that used prefix semantics.
     virtual_text_prefix = pwned_cfg.virtual_text_prefix,
   }
 end

--- a/lua/camouflage/pwned/ui.lua
+++ b/lua/camouflage/pwned/ui.lua
@@ -49,7 +49,8 @@ end
 ---@field show_virtual_text? boolean Show virtual text (default: true)
 ---@field show_line_highlight? boolean Highlight entire line (default: true)
 ---@field sign_text? string Sign text (default: "!")
----@field virtual_text_prefix? string Prefix for virtual text (default: " PWNED: ")
+---@field virtual_text_format? string Format for virtual text (default: "PWNED (%s) exposures")
+---@field virtual_text_prefix? string Deprecated: prefix for virtual text, used as fallback
 
 ---Mark a line as pwned
 ---@param bufnr number Buffer number
@@ -62,7 +63,12 @@ function M.mark_pwned(bufnr, line, count, config)
   local show_virtual_text = config.show_virtual_text ~= false
   local show_line_highlight = config.show_line_highlight ~= false
   local sign_text = config.sign_text or '!'
-  local virtual_text_prefix = config.virtual_text_prefix or ' PWNED: '
+  local virtual_text_format = config.virtual_text_format
+
+  if not virtual_text_format then
+    local virtual_text_prefix = config.virtual_text_prefix or ' PWNED: '
+    virtual_text_format = virtual_text_prefix .. '%s exposures'
+  end
 
   -- Validate buffer and line
   if not vim.api.nvim_buf_is_valid(bufnr) then
@@ -95,7 +101,7 @@ function M.mark_pwned(bufnr, line, count, config)
   if show_virtual_text then
     local formatted = M.format_count(count)
     extmark_opts.virt_text = {
-      { virtual_text_prefix .. formatted .. ' exposures', 'CamouflagePwnedVirtualText' },
+      { string.format(virtual_text_format, formatted), 'CamouflagePwnedVirtualText' },
     }
     extmark_opts.virt_text_pos = 'eol'
   end

--- a/tests/camouflage/pwned/ui_spec.lua
+++ b/tests/camouflage/pwned/ui_spec.lua
@@ -60,7 +60,7 @@ describe('camouflage.pwned.ui', function()
         show_line_highlight = true,
         sign_text = '!',
         sign_hl = 'DiagnosticWarn',
-        virtual_text_prefix = ' PWNED: ',
+        virtual_text_format = ' PWNED: %s exposures',
         virtual_text_hl = 'DiagnosticWarn',
         line_hl = 'CamouflagePwned',
       }
@@ -85,7 +85,7 @@ describe('camouflage.pwned.ui', function()
         show_line_highlight = true,
         sign_text = '!',
         sign_hl = 'DiagnosticWarn',
-        virtual_text_prefix = ' PWNED: ',
+        virtual_text_format = ' PWNED: %s exposures',
         virtual_text_hl = 'DiagnosticWarn',
         line_hl = 'CamouflagePwned',
       }
@@ -131,6 +131,23 @@ describe('camouflage.pwned.ui', function()
       -- Verify only 2 marks remain (lines 0 and 2)
       extmarks = vim.api.nvim_buf_get_extmarks(bufnr, ui.get_namespace(), 0, -1, {})
       assert.equals(2, #extmarks)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('should support deprecated virtual_text_prefix as fallback', function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'PASSWORD=secret123' })
+
+      ui.mark_pwned(bufnr, 0, 1000, {
+        virtual_text_prefix = ' PWNED: ',
+      })
+
+      local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, ui.get_namespace(), 0, -1, {
+        details = true,
+      })
+      local details = extmarks[1][4]
+      assert.same({ { ' PWNED: 1K exposures', 'CamouflagePwnedVirtualText' } }, details.virt_text)
 
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)


### PR DESCRIPTION
## Description

  Align the pwned virtual text configuration so the documented pwned.virtual_text_format option is actually used at runtime.

  This change updates the pwned UI config flow to pass and render virtual_text_format, while keeping virtual_text_prefix as a backward-compatible fallback for older configs. It
  also adds test coverage for both the new primary path and the deprecated fallback behavior.

  ## Related Issue

  N/A

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)

  ## Checklist

  - [x] My code follows the project's code style
  - [ ] I have run make lint and make format
  - [x] I have added tests that prove my fix/feature works
  - [ ] All new and existing tests pass (make test)
  - [ ] I have updated the documentation if needed
  - [x] My commit messages follow conventional commits format

  ## Screenshots (if applicable)

  N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `virtual_text_format` configuration option, enabling flexible customization of virtual text display with format string support for exposure count formatting.

* **Deprecations**
  * `virtual_text_prefix` is deprecated in favor of the new format option; existing configurations remain functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->