### PR TITLE
feat(parsers): add public API for registering custom parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A Neovim plugin that visually masks secrets in `.env`, `.json`, `.yaml`, `.toml`
 - **TreeSitter Support**: Enhanced parsing for JSON/YAML/TOML/XML/HTTP/HCL/Dockerfile
 - **Telescope/Snacks Integration**: Mask values in preview buffers
 - **Zero file modification**: All masking is purely visual
+- **Extensible**: Register custom parsers for unsupported formats via a public API
 
 ## Installation
 
@@ -139,6 +140,7 @@ require('camouflage').setup({
 | `:CamouflagePwnedCheck` | Check if value under cursor is pwned |
 | `:CamouflagePwnedCheckBuffer` | Check all values in buffer |
 | `:CamouflageInit` | Create `.camouflage.yaml` in project root |
+| `:CamouflageParsers` | List registered parsers (debug) |
 
 > **[Full commands list](https://github.com/zeybek/camouflage.nvim/wiki/Commands-and-Keymaps)** on the wiki.
 

--- a/doc/camouflage.txt
+++ b/doc/camouflage.txt
@@ -16,12 +16,13 @@ CONTENTS                                                  *camouflage-contents*
   7. Buffer-local Configuration .............. |camouflage-buffer-local|
   8. Supported Formats ....................... |camouflage-formats|
   9. Custom Patterns ......................... |camouflage-custom-patterns|
- 10. Styles .................................. |camouflage-styles|
- 11. Integrations ............................ |camouflage-integrations|
- 12. Project Config .......................... |camouflage-project-config|
- 13. Have I Been Pwned ....................... |camouflage-pwned|
- 14. Custom Queries .......................... |camouflage-custom-queries|
- 15. Troubleshooting ......................... |camouflage-troubleshooting|
+ 10. Custom Parsers .......................... |camouflage-custom-parsers|
+ 11. Styles .................................. |camouflage-styles|
+ 12. Integrations ............................ |camouflage-integrations|
+ 13. Project Config .......................... |camouflage-project-config|
+ 14. Have I Been Pwned ....................... |camouflage-pwned|
+ 15. Custom Queries .......................... |camouflage-custom-queries|
+ 16. Troubleshooting ......................... |camouflage-troubleshooting|
 
 ==============================================================================
 INTRODUCTION                                          *camouflage-introduction*
@@ -258,6 +259,12 @@ COMMANDS                                                  *camouflage-commands*
 :CamouflageRefresh
   Refresh decorations for all visible buffers.
 
+                                                         *:CamouflageParsers*
+:CamouflageParsers
+  List all registered parsers with their priority, source (builtin/user),
+  filetypes and file_patterns. Useful for debugging custom parser
+  registration and resolution order.
+
                                                           *:CamouflageStatus*
 :CamouflageStatus
   Show camouflage status including:
@@ -340,6 +347,34 @@ camouflage.refresh()
                                                           *camouflage.version*
 camouflage.version
   String containing the current plugin version.
+
+                                                  *camouflage.register_parser()*
+camouflage.register_parser({spec})
+  Register a custom parser. See |camouflage-custom-parsers| for details.
+
+  Parameters: ~
+    {spec}  Table with: name, parser (or parse fn), filetypes?,
+            file_patterns?, priority?, treesitter?
+
+                                                 *camouflage.register_pattern()*
+camouflage.register_pattern({spec})
+  Shorthand to register a simple Lua-pattern based parser.
+
+  Parameters: ~
+    {spec}  Table with: name, file_patterns, pattern, value_capture,
+            key_capture?, filetypes?, priority?
+
+                                                *camouflage.unregister_parser()*
+camouflage.unregister_parser({name})
+  Remove a registered parser. Works for builtins too.
+
+                                                     *camouflage.list_parsers()*
+camouflage.list_parsers()
+  Return all registered parser entries sorted by priority (desc).
+
+                                                       *camouflage.get_parser()*
+camouflage.get_parser({name})
+  Return the parser table registered under {name}, or nil.
 
                                                      *camouflage.pwned_check()*
 camouflage.pwned_check()
@@ -494,6 +529,80 @@ Use autocommands to apply buffer-local settings for specific projects:
 
 Note: After setting buffer variables, call `:CamouflageRefresh` to apply
 the changes immediately.
+
+==============================================================================
+CUSTOM PARSERS                                          *camouflage-custom-parsers*
+
+You can register parsers for unsupported file formats at runtime via the
+public API. Three levels are supported:
+
+1. Pattern-based (simple Lua pattern) ~
+
+>lua
+    require('camouflage').register_pattern({
+      name = 'kdl_tokens',
+      file_patterns = { '*.kdl' },
+      pattern = '(%w+)%s+"([^"]+)"',
+      key_capture = 1,
+      value_capture = 2,
+    })
+<
+
+2. Full parser (Lua function) ~
+
+>lua
+    require('camouflage').register_parser({
+      name = 'my_format',
+      filetypes = { 'myft' },
+      file_patterns = { '*.myft' },
+      priority = 60,             -- default 50, higher wins on conflict
+      parser = {
+        parse = function(content, bufnr)
+          -- return ParsedVariable[]
+          return {
+            {
+              key = 'token',
+              value = 'abc',
+              start_index = 0,
+              end_index = 3,
+              line_number = 0,
+              is_nested = false,
+              is_commented = false,
+            },
+          }
+        end,
+      },
+    })
+<
+
+3. TreeSitter-backed parser ~
+
+>lua
+    require('camouflage').register_parser({
+      name = 'kdl_ts',
+      filetypes = { 'kdl' },
+      file_patterns = { '*.kdl' },
+      parser = {
+        parse = function(content, bufnr)
+          return require('camouflage.treesitter').parse(bufnr, 'kdl', content) or {}
+        end,
+      },
+      treesitter = {
+        lang = 'kdl',
+        query = [[
+          (node (identifier) @key
+                (string (string_fragment) @value))
+        ]],
+      },
+    })
+<
+
+Other API functions: ~
+
+- `camouflage.unregister_parser(name)` — remove a parser (builtins allowed)
+- `camouflage.list_parsers()` — list all registered parsers
+- `camouflage.get_parser(name)` — fetch a parser by name
+- `:CamouflageParsers` — inspect current registry
 
 ==============================================================================
 SUPPORTED FORMATS                                          *camouflage-formats*

--- a/lua/camouflage/commands.lua
+++ b/lua/camouflage/commands.lua
@@ -12,6 +12,31 @@ function M.setup()
     vim.notify('[camouflage] ' .. status, vim.log.levels.INFO)
   end, { desc = 'Toggle Camouflage' })
 
+  vim.api.nvim_create_user_command('CamouflageParsers', function()
+    local entries = require('camouflage.parsers').list()
+    if #entries == 0 then
+      vim.notify('[camouflage] No parsers registered', vim.log.levels.INFO)
+      return
+    end
+    local lines = { '[camouflage] Registered parsers:' }
+    for _, e in ipairs(entries) do
+      local fts = e.filetypes and table.concat(e.filetypes, ',') or '-'
+      local pats = e.file_patterns and table.concat(e.file_patterns, ',') or '-'
+      table.insert(
+        lines,
+        string.format(
+          '  %-14s priority=%-3d source=%-7s filetypes=%s patterns=%s',
+          e.name,
+          e.priority or 50,
+          e.source or '-',
+          fts,
+          pats
+        )
+      )
+    end
+    vim.notify(table.concat(lines, '\n'), vim.log.levels.INFO)
+  end, { desc = 'List registered camouflage parsers' })
+
   vim.api.nvim_create_user_command('CamouflageRefresh', function()
     require('camouflage').refresh()
     vim.notify('[camouflage] refreshed', vim.log.levels.INFO)

--- a/lua/camouflage/init.lua
+++ b/lua/camouflage/init.lua
@@ -492,6 +492,79 @@ M.pwned_is_available = function()
   return require('camouflage.pwned').is_available()
 end
 
+-- Parser API
+---Register a custom parser.
+---
+---Spec fields:
+---  name (string, required)
+---  parser (table with parse function) OR provide `parse` directly on spec
+---  filetypes (string[], optional)         -- vim filetypes to match
+---  file_patterns (string[], optional)     -- basename globs ('*.kdl', 'Foo*')
+---  priority (integer, optional, default 50)
+---  treesitter (table, optional) { lang, query?, query_file? }
+---
+---@param spec table
+function M.register_parser(spec)
+  assert(type(spec) == 'table' and spec.name, 'register_parser requires a spec with .name')
+
+  if spec.treesitter then
+    local ts_spec = spec.treesitter
+    if ts_spec.lang and ts_spec.query then
+      require('camouflage.treesitter').register_query(ts_spec.lang, ts_spec.query)
+    end
+  end
+
+  require('camouflage.parsers').register(spec)
+end
+
+---Register a simple pattern-based parser. Shorthand for custom Lua-pattern matching.
+---@param spec { name: string, file_patterns: string[], filetypes?: string[], pattern: string, key_capture?: integer, value_capture: integer, priority?: integer }
+function M.register_pattern(spec)
+  assert(
+    type(spec) == 'table' and spec.name and spec.pattern and spec.value_capture,
+    'register_pattern requires name, pattern, value_capture'
+  )
+
+  local custom = require('camouflage.parsers.custom')
+  local pattern_config = {
+    file_pattern = spec.file_patterns or {},
+    pattern = spec.pattern,
+    key_capture = spec.key_capture,
+    value_capture = spec.value_capture,
+  }
+
+  M.register_parser({
+    name = spec.name,
+    filetypes = spec.filetypes,
+    file_patterns = spec.file_patterns,
+    priority = spec.priority,
+    parser = {
+      parse = function(content, _bufnr)
+        return custom.parse(content, pattern_config)
+      end,
+    },
+  })
+end
+
+---Unregister a parser by name (works for builtins too).
+---@param name string
+function M.unregister_parser(name)
+  require('camouflage.parsers').unregister(name)
+end
+
+---List all registered parsers.
+---@return CamouflageParserEntry[]
+function M.list_parsers()
+  return require('camouflage.parsers').list()
+end
+
+---Get a registered parser by name.
+---@param name string
+---@return table|nil
+function M.get_parser(name)
+  return require('camouflage.parsers').get(name)
+end
+
 -- Repo project config API
 M.project_config_status = function()
   return require('camouflage.project_config').status()

--- a/lua/camouflage/parsers/dockerfile.lua
+++ b/lua/camouflage/parsers/dockerfile.lua
@@ -368,4 +368,9 @@ function M.find_value_position(line, prefix, value, line_start)
   return { start = line_start + value_start - 1 }
 end
 
+M.filetypes = { 'dockerfile' }
+M.file_patterns =
+  { 'Dockerfile', 'Dockerfile.*', '*.dockerfile', 'Containerfile', 'Containerfile.*' }
+M.treesitter = { lang = 'dockerfile' }
+
 return M

--- a/lua/camouflage/parsers/env.lua
+++ b/lua/camouflage/parsers/env.lua
@@ -91,4 +91,7 @@ function M.parse_line(line, line_num, current_index, parser_config)
   }
 end
 
+M.filetypes = { 'sh', 'bash', 'zsh' }
+M.file_patterns = { '.env*', '*.env', '.envrc', '*.sh' }
+
 return M

--- a/lua/camouflage/parsers/hcl.lua
+++ b/lua/camouflage/parsers/hcl.lua
@@ -370,4 +370,8 @@ function M.is_function_call(value)
   return value:match('^[a-zA-Z_][a-zA-Z0-9_]*%s*%(') ~= nil
 end
 
+M.filetypes = { 'hcl', 'terraform', 'tf' }
+M.file_patterns = { '*.tf', '*.tfvars', '*.hcl' }
+M.treesitter = { lang = 'hcl' }
+
 return M

--- a/lua/camouflage/parsers/http.lua
+++ b/lua/camouflage/parsers/http.lua
@@ -86,4 +86,8 @@ function M.parse_line(line, line_num, current_index)
   }
 end
 
+M.filetypes = { 'http' }
+M.file_patterns = { '*.http' }
+M.treesitter = { lang = 'http' }
+
 return M

--- a/lua/camouflage/parsers/init.lua
+++ b/lua/camouflage/parsers/init.lua
@@ -14,23 +14,93 @@ local config = require('camouflage.config')
 ---@field is_commented boolean
 ---@field is_multiline boolean|nil
 
+---@class CamouflageTSParserSpec
+---@field lang string
+---@field query? string
+---@field query_file? string
+
+---@class CamouflageParserEntry
+---@field name string
+---@field parser table
+---@field filetypes? string[]
+---@field file_patterns? string[]
+---@field priority? integer
+---@field treesitter? CamouflageTSParserSpec
+---@field source? string  -- 'builtin' | 'user'
+
 ---@type table<string, table>
 M.parsers = {}
+
+-- Rich metadata registry. M.parsers stays as the primary storage for
+-- backward compatibility (tests and external callers read it directly).
+---@type table<string, CamouflageParserEntry>
+M.entries = {}
+
+local DEFAULT_PRIORITY = 50
 
 -- Simple cache for find_parser_for_file to avoid repeated lookups
 ---@type {filename: string|nil, parser: table|nil, parser_name: string|nil}
 local parser_cache = { filename = nil, parser = nil, parser_name = nil }
 
+---Register a parser.
+---
+---Supports two call forms:
+---  - register(name, parser_table)         -- legacy
+---  - register(spec) where spec has .name  -- new, accepts metadata
+---@param name_or_spec string|CamouflageParserEntry
+---@param parser? table
+function M.register(name_or_spec, parser)
+  local entry
+  if type(name_or_spec) == 'string' then
+    entry = { name = name_or_spec, parser = parser }
+  else
+    entry = vim.deepcopy(name_or_spec)
+    -- Allow passing parser table directly as the spec (must have .parse and .name)
+    if not entry.parser and type(entry.parse) == 'function' then
+      entry.parser = { parse = entry.parse }
+    end
+  end
+
+  assert(entry.name, 'parser registration requires a name')
+  assert(
+    entry.parser and type(entry.parser.parse) == 'function',
+    'parser must have a parse function'
+  )
+
+  entry.priority = entry.priority or DEFAULT_PRIORITY
+  entry.source = entry.source or 'user'
+
+  M.parsers[entry.name] = entry.parser
+  M.entries[entry.name] = entry
+  M.clear_cache()
+end
+
 ---@param name string
----@param parser table
-function M.register(name, parser)
-  M.parsers[name] = parser
+function M.unregister(name)
+  M.parsers[name] = nil
+  M.entries[name] = nil
+  M.clear_cache()
 end
 
 ---@param name string
 ---@return table|nil
 function M.get(name)
   return M.parsers[name]
+end
+
+---@return CamouflageParserEntry[]
+function M.list()
+  local out = {}
+  for _, entry in pairs(M.entries) do
+    table.insert(out, entry)
+  end
+  table.sort(out, function(a, b)
+    if (a.priority or 0) ~= (b.priority or 0) then
+      return (a.priority or 0) > (b.priority or 0)
+    end
+    return a.name < b.name
+  end)
+  return out
 end
 
 ---@param filename string
@@ -74,6 +144,16 @@ function M.find_parser_for_file(filename)
     end
   end
 
+  -- Try parsers registered with metadata (file_patterns / filetypes).
+  -- Sorted by priority desc so user-registered parsers can override.
+  local entry_match = M.find_entry_for_file(filename)
+  if entry_match then
+    parser_cache.filename = filename
+    parser_cache.parser = entry_match.parser
+    parser_cache.parser_name = entry_match.name
+    return entry_match.parser, entry_match.name
+  end
+
   -- If no built-in parser found, check custom patterns
   local custom = require('camouflage.parsers.custom')
   local custom_pattern = custom.find_matching_pattern(filename)
@@ -96,6 +176,60 @@ function M.find_parser_for_file(filename)
   parser_cache.parser = nil
   parser_cache.parser_name = nil
   return nil, nil
+end
+
+---Find a parser entry whose registered filetypes/file_patterns match the file.
+---Higher priority wins; ties resolved by user-source before builtin.
+---@param filename string
+---@param filetype? string
+---@return CamouflageParserEntry|nil
+function M.find_entry_for_file(filename, filetype)
+  local basename = vim.fn.fnamemodify(filename, ':t')
+  local candidates = {}
+
+  for _, entry in pairs(M.entries) do
+    local matched = false
+
+    if filetype and entry.filetypes then
+      for _, ft in ipairs(entry.filetypes) do
+        if ft == filetype then
+          matched = true
+          break
+        end
+      end
+    end
+
+    if not matched and entry.file_patterns then
+      for _, pat in ipairs(entry.file_patterns) do
+        if M.match_pattern(basename, pat) then
+          matched = true
+          break
+        end
+      end
+    end
+
+    if matched then
+      table.insert(candidates, entry)
+    end
+  end
+
+  if #candidates == 0 then
+    return nil
+  end
+
+  table.sort(candidates, function(a, b)
+    local pa, pb = a.priority or DEFAULT_PRIORITY, b.priority or DEFAULT_PRIORITY
+    if pa ~= pb then
+      return pa > pb
+    end
+    -- user-registered beats builtin on tie
+    if a.source ~= b.source then
+      return a.source == 'user'
+    end
+    return a.name < b.name
+  end)
+
+  return candidates[1]
 end
 
 ---@param filename string
@@ -170,16 +304,34 @@ end
 function M.setup()
   -- Clear cache when setup is called (config may have changed)
   M.clear_cache()
-  M.register('env', require('camouflage.parsers.env'))
-  M.register('json', require('camouflage.parsers.json'))
-  M.register('yaml', require('camouflage.parsers.yaml'))
-  M.register('toml', require('camouflage.parsers.toml'))
-  M.register('properties', require('camouflage.parsers.properties'))
-  M.register('netrc', require('camouflage.parsers.netrc'))
-  M.register('xml', require('camouflage.parsers.xml'))
-  M.register('http', require('camouflage.parsers.http'))
-  M.register('hcl', require('camouflage.parsers.hcl'))
-  M.register('dockerfile', require('camouflage.parsers.dockerfile'))
+  M.parsers = {}
+  M.entries = {}
+
+  local builtins = {
+    { name = 'env', module = 'camouflage.parsers.env' },
+    { name = 'json', module = 'camouflage.parsers.json' },
+    { name = 'yaml', module = 'camouflage.parsers.yaml' },
+    { name = 'toml', module = 'camouflage.parsers.toml' },
+    { name = 'properties', module = 'camouflage.parsers.properties' },
+    { name = 'netrc', module = 'camouflage.parsers.netrc' },
+    { name = 'xml', module = 'camouflage.parsers.xml' },
+    { name = 'http', module = 'camouflage.parsers.http' },
+    { name = 'hcl', module = 'camouflage.parsers.hcl' },
+    { name = 'dockerfile', module = 'camouflage.parsers.dockerfile' },
+  }
+
+  for _, b in ipairs(builtins) do
+    local mod = require(b.module)
+    M.register({
+      name = b.name,
+      parser = mod,
+      filetypes = mod.filetypes,
+      file_patterns = mod.file_patterns,
+      priority = mod.priority,
+      treesitter = mod.treesitter,
+      source = 'builtin',
+    })
+  end
 end
 
 return M

--- a/lua/camouflage/parsers/json.lua
+++ b/lua/camouflage/parsers/json.lua
@@ -229,4 +229,8 @@ function M.get_line_number(content, index)
   return count
 end
 
+M.filetypes = { 'json', 'jsonc' }
+M.file_patterns = { '*.json' }
+M.treesitter = { lang = 'json' }
+
 return M

--- a/lua/camouflage/parsers/netrc.lua
+++ b/lua/camouflage/parsers/netrc.lua
@@ -157,4 +157,7 @@ function M.parse(content, _bufnr)
   return variables
 end
 
+M.filetypes = { 'netrc' }
+M.file_patterns = { '.netrc', '_netrc' }
+
 return M

--- a/lua/camouflage/parsers/properties.lua
+++ b/lua/camouflage/parsers/properties.lua
@@ -92,4 +92,7 @@ function M.process_line(line, line_num, line_start, current_section, include_com
   }
 end
 
+M.filetypes = { 'properties', 'dosini', 'config' }
+M.file_patterns = { '*.properties', '*.ini', '*.conf', 'credentials' }
+
 return M

--- a/lua/camouflage/parsers/toml.lua
+++ b/lua/camouflage/parsers/toml.lua
@@ -181,4 +181,8 @@ function M.parse_value(raw_value)
   return raw_value, 0
 end
 
+M.filetypes = { 'toml' }
+M.file_patterns = { '*.toml' }
+M.treesitter = { lang = 'toml' }
+
 return M

--- a/lua/camouflage/parsers/xml.lua
+++ b/lua/camouflage/parsers/xml.lua
@@ -293,4 +293,8 @@ function M.get_line_number(content, index)
   return count
 end
 
+M.filetypes = { 'xml' }
+M.file_patterns = { '*.xml' }
+M.treesitter = { lang = 'xml' }
+
 return M

--- a/lua/camouflage/parsers/yaml.lua
+++ b/lua/camouflage/parsers/yaml.lua
@@ -296,4 +296,8 @@ function M.build_key_path(stack, current_key)
   return stack[#stack].key .. '.' .. current_key
 end
 
+M.filetypes = { 'yaml' }
+M.file_patterns = { '*.yaml', '*.yml' }
+M.treesitter = { lang = 'yaml' }
+
 return M

--- a/lua/camouflage/treesitter.lua
+++ b/lua/camouflage/treesitter.lua
@@ -68,26 +68,72 @@ local fallback_queries = {
   ]],
 }
 
----Get query for language (file-based with fallback)
+-- Runtime-registered queries (by language). These take precedence over
+-- queries/<lang>/camouflage.scm so 3rd party parsers can ship TS support
+-- without touching the runtimepath.
+---@type table<string, string>
+M.runtime_queries = {}
+
+-- Parsed query cache to avoid re-parsing on every buffer.
+---@type table<string, vim.treesitter.Query|false>
+local parsed_query_cache = {}
+
+---Register a TreeSitter query for a language at runtime.
+---@param lang string
+---@param query_string string
+function M.register_query(lang, query_string)
+  M.runtime_queries[lang] = query_string
+  parsed_query_cache[lang] = nil
+end
+
+---@param lang string
+function M.unregister_query(lang)
+  M.runtime_queries[lang] = nil
+  parsed_query_cache[lang] = nil
+end
+
+---Get query for language. Resolution order:
+---  1. Runtime-registered query (M.runtime_queries)
+---  2. queries/<lang>/camouflage.scm from runtimepath
+---  3. Hardcoded fallback_queries
 ---@param lang string
 ---@return vim.treesitter.Query|nil
 local function get_query(lang)
-  -- Try to load from file first
+  local cached = parsed_query_cache[lang]
+  if cached ~= nil then
+    return cached or nil
+  end
+
+  -- 1. Runtime-registered
+  local runtime_q = M.runtime_queries[lang]
+  if runtime_q then
+    local ok, parsed = pcall(vim.treesitter.query.parse, lang, runtime_q)
+    if ok and parsed then
+      parsed_query_cache[lang] = parsed
+      return parsed
+    end
+    log.debug('Failed to parse runtime query for %s', lang)
+  end
+
+  -- 2. File-based (runtimepath)
   local ok, query = pcall(vim.treesitter.query.get, lang, 'camouflage')
   if ok and query then
+    parsed_query_cache[lang] = query
     return query
   end
 
-  -- Fallback to inline query
+  -- 3. Hardcoded fallback
   local query_string = fallback_queries[lang]
   if query_string then
     local parse_ok, parsed = pcall(vim.treesitter.query.parse, lang, query_string)
     if parse_ok and parsed then
       log.debug('Using fallback query for %s', lang)
+      parsed_query_cache[lang] = parsed
       return parsed
     end
   end
 
+  parsed_query_cache[lang] = false
   return nil
 end
 
@@ -141,6 +187,13 @@ M.value_types = {
     'unquoted_string',
   },
 }
+
+---Register value node types for a language (what counts as a "value", not a container).
+---@param lang string
+---@param types string[]
+function M.register_value_types(lang, types)
+  M.value_types[lang] = types
+end
 
 ---Check if TreeSitter parser is available for a language
 ---@param lang string Language name (e.g., 'json', 'yaml', 'toml')

--- a/tests/camouflage/parsers/api_spec.lua
+++ b/tests/camouflage/parsers/api_spec.lua
@@ -1,0 +1,152 @@
+local camouflage = require('camouflage')
+local parsers = require('camouflage.parsers')
+local config = require('camouflage.config')
+
+describe('camouflage parser public API', function()
+  before_each(function()
+    config.setup()
+    parsers.setup()
+  end)
+
+  describe('register_parser', function()
+    it('registers a parser with metadata and resolves by file_patterns', function()
+      camouflage.register_parser({
+        name = 'kdl',
+        file_patterns = { '*.kdl' },
+        parser = {
+          parse = function()
+            return {
+              {
+                key = 'k',
+                value = 'v',
+                start_index = 0,
+                end_index = 1,
+                line_number = 0,
+                is_nested = false,
+                is_commented = false,
+              },
+            }
+          end,
+        },
+      })
+
+      local parser, name = parsers.find_parser_for_file('app.kdl')
+      assert.is_not_nil(parser)
+      assert.equals('kdl', name)
+    end)
+
+    it('higher priority wins on conflict', function()
+      camouflage.register_parser({
+        name = 'low',
+        file_patterns = { '*.dup' },
+        priority = 10,
+        parser = {
+          parse = function()
+            return {}
+          end,
+        },
+      })
+      camouflage.register_parser({
+        name = 'high',
+        file_patterns = { '*.dup' },
+        priority = 100,
+        parser = {
+          parse = function()
+            return {}
+          end,
+        },
+      })
+
+      local _, name = parsers.find_parser_for_file('x.dup')
+      assert.equals('high', name)
+    end)
+
+    it('config.patterns takes precedence over entry resolution', function()
+      -- builtin json parser is matched via config.patterns first
+      local _, name = parsers.find_parser_for_file('config.json')
+      assert.equals('json', name)
+    end)
+  end)
+
+  describe('register_pattern', function()
+    it('registers a Lua-pattern based parser', function()
+      camouflage.register_pattern({
+        name = 'token_lines',
+        file_patterns = { '*.tok' },
+        pattern = '^(%w+)=(%S+)$',
+        key_capture = 1,
+        value_capture = 2,
+      })
+
+      local content = 'TOKEN=abc123'
+      local result = parsers.parse('foo.tok', content)
+      assert.is_table(result)
+      assert.equals(1, #result)
+      assert.equals('abc123', result[1].value)
+    end)
+  end)
+
+  describe('unregister_parser', function()
+    it('removes a registered parser', function()
+      camouflage.register_parser({
+        name = 'tmp',
+        file_patterns = { '*.tmp' },
+        parser = {
+          parse = function()
+            return {}
+          end,
+        },
+      })
+      assert.is_not_nil(parsers.get('tmp'))
+
+      camouflage.unregister_parser('tmp')
+      assert.is_nil(parsers.get('tmp'))
+    end)
+
+    it('can remove a builtin parser', function()
+      assert.is_not_nil(parsers.get('json'))
+      camouflage.unregister_parser('json')
+      assert.is_nil(parsers.get('json'))
+    end)
+  end)
+
+  describe('list_parsers', function()
+    it('returns all registered parsers sorted by priority desc', function()
+      camouflage.register_parser({
+        name = 'top',
+        file_patterns = { '*.top' },
+        priority = 999,
+        parser = {
+          parse = function()
+            return {}
+          end,
+        },
+      })
+
+      local list = camouflage.list_parsers()
+      assert.is_true(#list > 0)
+      assert.equals('top', list[1].name)
+    end)
+
+    it('marks builtin source', function()
+      local list = camouflage.list_parsers()
+      local found_builtin = false
+      for _, e in ipairs(list) do
+        if e.source == 'builtin' then
+          found_builtin = true
+          break
+        end
+      end
+      assert.is_true(found_builtin)
+    end)
+  end)
+
+  describe('get_parser', function()
+    it('returns nil for unknown parser', function()
+      assert.is_nil(camouflage.get_parser('nonexistent'))
+    end)
+    it('returns registered parser', function()
+      assert.is_not_nil(camouflage.get_parser('env'))
+    end)
+  end)
+end)

--- a/tests/camouflage/treesitter_registry_spec.lua
+++ b/tests/camouflage/treesitter_registry_spec.lua
@@ -1,0 +1,25 @@
+local ts = require('camouflage.treesitter')
+
+describe('camouflage.treesitter runtime registry', function()
+  after_each(function()
+    ts.unregister_query('my_lang')
+  end)
+
+  it('register_query stores the query string', function()
+    ts.register_query('my_lang', '(node) @value')
+    assert.equals('(node) @value', ts.runtime_queries['my_lang'])
+  end)
+
+  it('unregister_query clears the entry', function()
+    ts.register_query('my_lang', '(x) @y')
+    ts.unregister_query('my_lang')
+    assert.is_nil(ts.runtime_queries['my_lang'])
+  end)
+
+  it('register_value_types stores node types', function()
+    ts.register_value_types('my_lang', { 'string', 'number' })
+    assert.same({ 'string', 'number' }, ts.value_types['my_lang'])
+    assert.is_true(ts.is_value_type('my_lang', 'string'))
+    assert.is_false(ts.is_value_type('my_lang', 'object'))
+  end)
+end)


### PR DESCRIPTION
## Description

Adds a public API for registering custom parsers, enabling users and 3rd party plugins to support new file formats without forking the plugin.

Three registration levels:
- `register_pattern` — simple Lua-pattern (5 lines)
- `register_parser` — full Lua parse function with metadata (filetypes, file_patterns, priority)
- `treesitter` field on parser spec — runtime TS query registration

Also adds `unregister_parser`, `list_parsers`, `get_parser` and a `:CamouflageParsers` introspection command. Builtin parsers now expose `filetypes` / `file_patterns` / `treesitter` metadata. Legacy `register(name, table)` signature, `config.patterns`, and `config.custom_patterns` continue to work unchanged.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`) — 538/538
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extensible parser system allowing users to register custom parsers via public API functions.
  * Added `:CamouflageParsers` command to list all registered parsers.
  * Support for runtime TreeSitter query registration.

* **Documentation**
  * Updated help and README with Custom Parsers section and new API documentation.

* **Tests**
  * Added test coverage for parser API and TreeSitter registry functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zeybek/camouflage.nvim/pull/20)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->