### PR TITLE
fix: remediate review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Neovim plugin that visually masks secrets in `.env`, `.json`, `.yaml`, `.toml`
 - **Multiple styles**: `stars`, `dotted`, `text`, `scramble`
 - **Reveal & Yank**: Temporarily reveal or copy masked values
 - **Follow Cursor Mode**: Auto-reveal current line as you navigate
-- **Have I Been Pwned**: Check passwords against breach database (Neovim 0.10+)
+- **Have I Been Pwned**: Check passwords against breach database (Neovim 0.10+ with `vim.system`, plus `curl`)
 - **JWT Expiry Hints**: Decode `exp` claim and show "expires in 2h" badges
 - **Hot Reload**: Config changes apply immediately
 - **Event System**: Hooks for extending functionality
@@ -189,6 +189,9 @@ require('camouflage').setup({
 | Dockerfile | `Dockerfile`, `Containerfile`, `*.dockerfile` | No |
 
 For unsupported formats, you can define [custom patterns](https://github.com/zeybek/camouflage.nvim/wiki/Custom-Patterns).
+Runtime parser registrations with `file_patterns` are picked up by automatic masking immediately after registration.
+
+When TreeSitter is available, JSON/YAML/XML nested keys are reported with their full path. XML attributes use `parent.path@attribute` so attributes and child elements with the same name stay distinct.
 
 ## Documentation
 

--- a/doc/camouflage.txt
+++ b/doc/camouflage.txt
@@ -179,7 +179,7 @@ Call the setup function with your options: >lua
       },
     },
 
-    -- Have I Been Pwned (requires Neovim 0.10+)
+    -- Have I Been Pwned (requires Neovim 0.10+ with vim.system, plus curl)
     pwned = {
       enabled = true,             -- Enable the feature
       auto_check = true,          -- Check on BufEnter
@@ -304,7 +304,8 @@ COMMANDS                                                  *camouflage-commands*
                                                       *:CamouflagePwnedCheck*
 :CamouflagePwnedCheck
   Check if the value under cursor has been found in data breaches
-  using the Have I Been Pwned API. Requires Neovim 0.10+.
+  using the Have I Been Pwned API. Requires Neovim 0.10+ with `vim.system`
+  and `curl`.
 
                                                   *:CamouflagePwnedCheckLine*
 :CamouflagePwnedCheckLine
@@ -422,8 +423,8 @@ camouflage.pwned_clear()
 
                                                *camouflage.pwned_is_available()*
 camouflage.pwned_is_available()
-  Returns `true` if the pwned feature is available (Neovim 0.10+ and
-  required CLI tools are installed).
+  Returns `true` if the pwned feature is available (`vim.system` exists and
+  `curl` is installed).
 
                                           *camouflage.project_config_status()*
 camouflage.project_config_status()
@@ -632,6 +633,11 @@ Other API functions: ~
 - `camouflage.get_parser(name)` — fetch a parser by name
 - `:CamouflageParsers` — inspect current registry
 
+Runtime registrations that include `file_patterns` refresh automatic masking
+immediately after registration. Existing matching buffers are re-checked, and
+future BufEnter/TextChanged events use the new patterns without restarting
+Neovim.
+
 ==============================================================================
 SUPPORTED FORMATS                                          *camouflage-formats*
 
@@ -709,6 +715,8 @@ Netrc files ~
 XML files ~
   Extensions: .xml
   Supports element content and attributes
+  TreeSitter-backed attribute keys use `parent.path@attribute` so attributes
+  and child elements with the same name stay distinct.
   Useful for Maven settings.xml, pom.xml, Spring configs
   Example: >xml
     <settings>
@@ -1062,7 +1070,8 @@ in data breaches.
 Requirements ~
 - Neovim >= 0.10.0 (uses `vim.system`)
 - `curl` for API requests
-- `sha1sum` or `openssl` for password hashing
+- Password hashing is done in-process; no `sha1sum` or `openssl` dependency is
+  required.
 
 Privacy ~
                                                    *camouflage-pwned-privacy*

--- a/lua/camouflage/init.lua
+++ b/lua/camouflage/init.lua
@@ -8,6 +8,26 @@ M.version = '0.10.0'
 
 local initialized = false
 
+---Refresh static masking autocmds after parser registry changes.
+---@return nil
+local function refresh_after_parser_registry_change()
+  local state_ok, state = pcall(require, 'camouflage.state')
+  local static_autocmds_exist = state_ok
+    and #vim.api.nvim_get_autocmds({ group = state.augroup }) > 0
+
+  if not initialized and not static_autocmds_exist then
+    return
+  end
+
+  local ok, autocmds = pcall(require, 'camouflage.autocmds')
+  if not ok then
+    return
+  end
+
+  autocmds.setup()
+  autocmds.apply_to_loaded_buffers()
+end
+
 ---Setup nvim-cmp integration to disable completion in masked buffers
 ---@return nil
 local function setup_cmp_integration()
@@ -553,6 +573,7 @@ function M.register_parser(spec)
   end
 
   require('camouflage.parsers').register(spec)
+  refresh_after_parser_registry_change()
 end
 
 ---Register a simple pattern-based parser. Shorthand for custom Lua-pattern matching.
@@ -588,6 +609,7 @@ end
 ---@param name string
 function M.unregister_parser(name)
   require('camouflage.parsers').unregister(name)
+  refresh_after_parser_registry_change()
 end
 
 ---List all registered parsers.

--- a/lua/camouflage/pwned/api.lua
+++ b/lua/camouflage/pwned/api.lua
@@ -9,10 +9,10 @@ local M = {}
 
 local API_URL = 'https://api.pwnedpasswords.com/range/'
 
----Check if curl is available
+---Check if HIBP network checks can run in this Neovim process.
 ---@return boolean
 function M.is_available()
-  return vim.fn.executable('curl') == 1
+  return type(vim.system) == 'function' and vim.fn.executable('curl') == 1
 end
 
 ---@alias PwnedSuffixes table<string, number> Map of hash suffix to breach count
@@ -45,7 +45,7 @@ function M.check_prefix(prefix, callback)
   local wrapped_callback = vim.schedule_wrap(callback)
 
   if not M.is_available() then
-    wrapped_callback('curl not available', nil)
+    wrapped_callback('HIBP check unavailable (requires vim.system and curl)', nil)
     return
   end
 

--- a/lua/camouflage/pwned/init.lua
+++ b/lua/camouflage/pwned/init.lua
@@ -20,6 +20,8 @@ local check = require('camouflage.pwned.check')
 local ui = require('camouflage.pwned.ui')
 local cache = require('camouflage.pwned.cache')
 
+local UNAVAILABLE_MESSAGE = '[camouflage] HIBP check not available (requires vim.system and curl)'
+
 ---Get variables for pwned checking
 ---If camouflage has parsed variables, use those (performance optimization)
 ---Otherwise, parse the file ourselves (for when camouflage is disabled)
@@ -116,7 +118,7 @@ end
 ---@param callback fun(result: PwnedCheckResult|nil)|nil Optional callback
 function M.check_current(callback)
   if not M.is_available() then
-    vim.notify('[camouflage] HIBP check not available (curl not found)', vim.log.levels.WARN)
+    vim.notify(UNAVAILABLE_MESSAGE, vim.log.levels.WARN)
     if callback then
       callback(nil)
     end
@@ -164,7 +166,7 @@ end
 ---@param callback fun(results: table<string, PwnedCheckResult>)|nil Optional callback
 function M.check_line(callback)
   if not M.is_available() then
-    vim.notify('[camouflage] HIBP check not available (curl not found)', vim.log.levels.WARN)
+    vim.notify(UNAVAILABLE_MESSAGE, vim.log.levels.WARN)
     if callback then
       callback({})
     end
@@ -216,7 +218,7 @@ end
 ---@param callback fun(results: table<string, PwnedCheckResult>)|nil Optional callback
 function M.check_buffer(callback)
   if not M.is_available() then
-    vim.notify('[camouflage] HIBP check not available (curl not found)', vim.log.levels.WARN)
+    vim.notify(UNAVAILABLE_MESSAGE, vim.log.levels.WARN)
     if callback then
       callback({})
     end

--- a/lua/camouflage/reveal.lua
+++ b/lua/camouflage/reveal.lua
@@ -218,7 +218,7 @@ local function setup_auto_hide(bufnr, revealed_line)
           return true
         end
       end,
-      group = state.augroup,
+      group = state.runtime_augroup,
     }
   )
 end
@@ -468,7 +468,7 @@ function M.start_follow_cursor()
 
   -- Create global autocmd for cursor movement
   follow_state.autocmd_id = vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
-    group = state.augroup,
+    group = state.runtime_augroup,
     callback = function(args)
       on_follow_cursor_moved(args.buf)
     end,

--- a/lua/camouflage/state.lua
+++ b/lua/camouflage/state.lua
@@ -4,6 +4,7 @@ local M = {}
 
 M.namespace = vim.api.nvim_create_namespace('camouflage')
 M.augroup = vim.api.nvim_create_augroup('camouflage', { clear = true })
+M.runtime_augroup = vim.api.nvim_create_augroup('camouflage_runtime', { clear = true })
 
 ---@class BufferState
 ---@field enabled boolean

--- a/lua/camouflage/treesitter.lua
+++ b/lua/camouflage/treesitter.lua
@@ -229,6 +229,174 @@ function M.is_value_type(lang, node_type)
   return false
 end
 
+---@param text string|nil
+---@return string|nil
+local function normalize_key_text(text)
+  if type(text) ~= 'string' then
+    return nil
+  end
+  text = text:match('^%s*(.-)%s*$')
+  if text:match('^".*"$') or text:match("^'.*'$") then
+    text = text:sub(2, -2)
+  end
+  return text
+end
+
+---@param node userdata
+---@param field string
+---@return userdata|nil
+local function first_field_node(node, field)
+  local ok, nodes = pcall(function()
+    return node:field(field)
+  end)
+  if ok and nodes and nodes[1] then
+    return nodes[1]
+  end
+  return nil
+end
+
+---@param node userdata
+---@param node_type string
+---@return userdata|nil
+local function first_child_of_type(node, node_type)
+  for i = 0, node:child_count() - 1 do
+    local child = node:child(i)
+    if child and child:type() == node_type then
+      return child
+    end
+  end
+  return nil
+end
+
+---@param pair userdata
+---@param bufnr number
+---@return string|nil
+local function pair_key_text(pair, bufnr)
+  local key_node = first_field_node(pair, 'key')
+  if not key_node then
+    return nil
+  end
+  return normalize_key_text(vim.treesitter.get_node_text(key_node, bufnr))
+end
+
+---@param lang string
+---@param key_node userdata
+---@param bufnr number
+---@return string|nil key_path
+---@return boolean is_nested
+local function derive_pair_key_path(lang, key_node, bufnr)
+  if lang ~= 'json' and lang ~= 'yaml' then
+    return nil, false
+  end
+
+  local pair_types = lang == 'json' and { pair = true }
+    or { block_mapping_pair = true, flow_pair = true }
+
+  local parts = {}
+  local node = key_node
+  while node do
+    if pair_types[node:type()] then
+      local key = pair_key_text(node, bufnr)
+      if key and key ~= '' then
+        table.insert(parts, 1, key)
+      end
+    end
+    node = node:parent()
+  end
+
+  if #parts == 0 then
+    return nil, false
+  end
+  return table.concat(parts, '.'), #parts > 1
+end
+
+---@param element userdata
+---@param bufnr number
+---@return string|nil
+local function xml_element_name(element, bufnr)
+  local stag = first_child_of_type(element, 'STag')
+  if not stag then
+    return nil
+  end
+  local name = first_child_of_type(stag, 'Name')
+  if not name then
+    return nil
+  end
+  return normalize_key_text(vim.treesitter.get_node_text(name, bufnr))
+end
+
+---@param node userdata
+---@return userdata|nil
+local function xml_enclosing_element(node)
+  while node do
+    if node:type() == 'element' then
+      return node
+    end
+    node = node:parent()
+  end
+  return nil
+end
+
+---@param element userdata
+---@param bufnr number
+---@return string[]
+local function xml_element_path(element, bufnr)
+  local parts = {}
+  local node = element
+  while node do
+    if node:type() == 'element' then
+      local name = xml_element_name(node, bufnr)
+      if name and name ~= '' then
+        table.insert(parts, 1, name)
+      end
+    end
+    node = node:parent()
+  end
+  return parts
+end
+
+---@param key_node userdata
+---@param key_text string
+---@param bufnr number
+---@return string|nil key_path
+---@return boolean is_nested
+local function derive_xml_key_path(key_node, key_text, bufnr)
+  local element = xml_enclosing_element(key_node)
+  if not element then
+    return nil, false
+  end
+
+  local parts = xml_element_path(element, bufnr)
+  local parent = key_node:parent()
+  if parent and parent:type() == 'Attribute' then
+    if #parts == 0 then
+      return key_text, false
+    end
+    return table.concat(parts, '.') .. '@' .. key_text, true
+  end
+
+  if #parts == 0 then
+    return nil, false
+  end
+  return table.concat(parts, '.'), #parts > 1
+end
+
+---@param lang string
+---@param key_node userdata
+---@param fallback_key string
+---@param bufnr number
+---@return string key_path
+---@return boolean is_nested
+local function derive_key_path(lang, key_node, fallback_key, bufnr)
+  local key_path, is_nested
+  if lang == 'json' or lang == 'yaml' then
+    key_path, is_nested = derive_pair_key_path(lang, key_node, bufnr)
+  elseif lang == 'xml' then
+    key_path, is_nested = derive_xml_key_path(key_node, fallback_key, bufnr)
+  end
+  return key_path or fallback_key, is_nested == true
+end
+
 ---Parse a buffer using TreeSitter and extract key-value pairs
 ---@param bufnr number Buffer number
 ---@param lang string Language name
@@ -276,10 +444,7 @@ function M.parse(bufnr, lang, content)
       -- Store key for next value
       current_key = node
       current_key_text = node_text
-      -- Remove quotes from JSON keys
-      if lang == 'json' and current_key_text:match('^".*"$') then
-        current_key_text = current_key_text:sub(2, -2)
-      end
+      current_key_text = normalize_key_text(current_key_text)
     elseif capture_name == 'value' and current_key then
       local node_type = node:type()
 
@@ -316,13 +481,14 @@ function M.parse(bufnr, lang, content)
 
         -- Skip empty values
         if value ~= '' and not value:match('^%s*$') then
+          local key_path, is_nested = derive_key_path(lang, current_key, current_key_text, bufnr)
           table.insert(variables, {
-            key = current_key_text,
+            key = key_path,
             value = value,
             start_index = start_index,
             end_index = end_index,
             line_number = start_row,
-            is_nested = false, -- TODO: detect nesting
+            is_nested = is_nested,
             is_commented = false,
           })
         end

--- a/tests/camouflage/follow_cursor_spec.lua
+++ b/tests/camouflage/follow_cursor_spec.lua
@@ -23,6 +23,13 @@ describe('camouflage.reveal follow_cursor', function()
     return bufnr
   end
 
+  local function follow_cursor_autocmd_count()
+    return #vim.api.nvim_get_autocmds({
+      group = state.runtime_augroup,
+      event = 'CursorMoved',
+    })
+  end
+
   before_each(function()
     clear_camouflage_modules()
     require('camouflage').setup({
@@ -82,6 +89,30 @@ describe('camouflage.reveal follow_cursor', function()
       assert.is_true(reveal.is_revealed())
       local revealed = reveal.get_revealed()
       assert.equals(1, revealed.line)
+    end)
+
+    it('keeps its autocmd when static camouflage autocmds are reconfigured', function()
+      local bufnr = setup_test_buffer('API_KEY=secret\nDEBUG=true', '/tmp/test.env')
+      state.set_variables(bufnr, {
+        { key = 'API_KEY', value = 'secret', start_index = 8, end_index = 13 },
+        { key = 'DEBUG', value = 'true', start_index = 21, end_index = 24 },
+      })
+
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      reveal.start_follow_cursor()
+      assert.is_true(reveal.is_follow_cursor_enabled())
+      assert.equals(1, follow_cursor_autocmd_count())
+
+      require('camouflage.autocmds').setup()
+
+      assert.is_true(reveal.is_follow_cursor_enabled())
+      assert.equals(1, follow_cursor_autocmd_count())
+
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
+
+      assert.is_true(reveal.is_revealed())
+      assert.equals(2, reveal.get_revealed().line)
     end)
   end)
 

--- a/tests/camouflage/parsers/api_spec.lua
+++ b/tests/camouflage/parsers/api_spec.lua
@@ -1,11 +1,28 @@
 local camouflage = require('camouflage')
 local parsers = require('camouflage.parsers')
 local config = require('camouflage.config')
+local state = require('camouflage.state')
 
 describe('camouflage parser public API', function()
+  local function count_bufenter_pattern(pattern)
+    local count = 0
+    for _, autocmd in
+      ipairs(vim.api.nvim_get_autocmds({
+        group = state.augroup,
+        event = 'BufEnter',
+      }))
+    do
+      if autocmd.pattern == pattern then
+        count = count + 1
+      end
+    end
+    return count
+  end
+
   before_each(function()
     config.setup()
     parsers.setup()
+    require('camouflage.autocmds').setup()
   end)
 
   describe('register_parser', function()
@@ -33,6 +50,35 @@ describe('camouflage parser public API', function()
       local parser, name = parsers.find_parser_for_file('app.kdl')
       assert.is_not_nil(parser)
       assert.equals('kdl', name)
+    end)
+
+    it('refreshes automatic masking patterns after setup', function()
+      assert.equals(0, count_bufenter_pattern('*.kdl'))
+
+      camouflage.register_parser({
+        name = 'kdl',
+        file_patterns = { '*.kdl' },
+        parser = {
+          parse = function()
+            return {}
+          end,
+        },
+      })
+
+      assert.is_true(count_bufenter_pattern('*.kdl') > 0)
+
+      local first_count = count_bufenter_pattern('*.kdl')
+      camouflage.register_parser({
+        name = 'kdl',
+        file_patterns = { '*.kdl' },
+        parser = {
+          parse = function()
+            return {}
+          end,
+        },
+      })
+
+      assert.equals(first_count, count_bufenter_pattern('*.kdl'))
     end)
 
     it('higher priority wins on conflict', function()
@@ -84,6 +130,20 @@ describe('camouflage parser public API', function()
       assert.equals(1, #result)
       assert.equals('abc123', result[1].value)
     end)
+
+    it('refreshes automatic masking patterns after setup', function()
+      assert.equals(0, count_bufenter_pattern('*.tok'))
+
+      camouflage.register_pattern({
+        name = 'token_lines',
+        file_patterns = { '*.tok' },
+        pattern = '^(%w+)=(%S+)$',
+        key_capture = 1,
+        value_capture = 2,
+      })
+
+      assert.is_true(count_bufenter_pattern('*.tok') > 0)
+    end)
   end)
 
   describe('unregister_parser', function()
@@ -101,6 +161,23 @@ describe('camouflage parser public API', function()
 
       camouflage.unregister_parser('tmp')
       assert.is_nil(parsers.get('tmp'))
+    end)
+
+    it('refreshes automatic masking patterns after removing a user parser', function()
+      camouflage.register_parser({
+        name = 'tmp',
+        file_patterns = { '*.tmp' },
+        parser = {
+          parse = function()
+            return {}
+          end,
+        },
+      })
+      assert.is_true(count_bufenter_pattern('*.tmp') > 0)
+
+      camouflage.unregister_parser('tmp')
+
+      assert.equals(0, count_bufenter_pattern('*.tmp'))
     end)
 
     it('can remove a builtin parser', function()

--- a/tests/camouflage/pwned/api_spec.lua
+++ b/tests/camouflage/pwned/api_spec.lua
@@ -11,6 +11,16 @@ end
 describe('camouflage.pwned.api', function()
   local api
 
+  local function with_system_unavailable(fn)
+    local original_system = vim.system
+    vim.system = nil
+    local ok, err = pcall(fn)
+    vim.system = original_system
+    if not ok then
+      error(err, 0)
+    end
+  end
+
   before_each(function()
     api = require('camouflage.pwned.api')
   end)
@@ -19,6 +29,37 @@ describe('camouflage.pwned.api', function()
     it('should return true when curl is available', function()
       -- curl should be available on most systems
       assert.is_true(api.is_available())
+    end)
+
+    it('returns false when vim.system is unavailable', function()
+      with_system_unavailable(function()
+        assert.is_false(api.is_available())
+      end)
+    end)
+  end)
+
+  describe('check_prefix', function()
+    it('reports unavailable instead of throwing when vim.system is absent', function()
+      with_system_unavailable(function()
+        local done = false
+        local err
+        local suffixes = 'unset'
+        assert.has_no.errors(function()
+          api.check_prefix('ABCDE', function(e, s)
+            err = e
+            suffixes = s
+            done = true
+          end)
+        end)
+
+        vim.wait(500, function()
+          return done
+        end)
+
+        assert.is_true(done)
+        assert.matches('unavailable', err)
+        assert.is_nil(suffixes)
+      end)
     end)
   end)
 

--- a/tests/camouflage/pwned/init_spec.lua
+++ b/tests/camouflage/pwned/init_spec.lua
@@ -11,6 +11,16 @@ end
 describe('camouflage.pwned', function()
   local pwned
 
+  local function with_system_unavailable(fn)
+    local original_system = vim.system
+    vim.system = nil
+    local ok, err = pcall(fn)
+    vim.system = original_system
+    if not ok then
+      error(err, 0)
+    end
+  end
+
   before_each(function()
     pwned = require('camouflage.pwned')
   end)
@@ -30,8 +40,40 @@ describe('camouflage.pwned', function()
     end)
 
     it('should return true when dependencies are met', function()
-      -- Hashing is in-process now; the only remaining dependency is curl.
+      -- Hashing is in-process; network checks need curl and vim.system.
       assert.is_true(pwned.is_available())
+    end)
+
+    it('returns false when vim.system is unavailable', function()
+      with_system_unavailable(function()
+        assert.is_false(pwned.is_available())
+      end)
+    end)
+  end)
+
+  describe('unavailable runtime', function()
+    it('public check entrypoints exit through callbacks without throwing', function()
+      with_system_unavailable(function()
+        local current_result = 'unset'
+        local line_result = 'unset'
+        local buffer_result = 'unset'
+
+        assert.has_no.errors(function()
+          pwned.check_current(function(result)
+            current_result = result
+          end)
+          pwned.check_line(function(results)
+            line_result = results
+          end)
+          pwned.check_buffer(function(results)
+            buffer_result = results
+          end)
+        end)
+
+        assert.is_nil(current_result)
+        assert.same({}, line_result)
+        assert.same({}, buffer_result)
+      end)
     end)
   end)
 

--- a/tests/camouflage/treesitter_spec.lua
+++ b/tests/camouflage/treesitter_spec.lua
@@ -94,6 +94,7 @@ describe('camouflage.treesitter', function()
   describe('parse with treesitter (integration)', function()
     local json_parser_available = ts.has_parser('json')
     local yaml_parser_available = ts.has_parser('yaml')
+    local xml_parser_available = ts.has_parser('xml')
 
     if json_parser_available then
       it('should parse JSON content', function()
@@ -113,6 +114,34 @@ describe('camouflage.treesitter', function()
           assert.equals(1, #result)
           assert.equals('key', result[1].key)
           assert.equals('value', result[1].value)
+        end
+      end)
+
+      it('should expose nested JSON key paths', function()
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local lines = {
+          '{',
+          '  "database": {',
+          '    "connection": { "password": "secret" }',
+          '  }',
+          '}',
+        }
+        local content = table.concat(lines, '\n')
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+        vim.api.nvim_set_option_value('filetype', 'json', { buf = bufnr })
+
+        local result = ts.parse(bufnr, 'json', content)
+
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+
+        if result then
+          local by_key = {}
+          for _, v in ipairs(result) do
+            by_key[v.key] = v
+            assert.equals(v.value, content:sub(v.start_index + 1, v.end_index))
+          end
+          assert.equals('secret', by_key['database.connection.password'].value)
+          assert.is_true(by_key['database.connection.password'].is_nested)
         end
       end)
     end
@@ -153,8 +182,34 @@ describe('camouflage.treesitter', function()
           for _, v in ipairs(result) do
             keys[v.key] = v.value
           end
-          assert.equals('hidden123', keys['secret'])
-          assert.equals('sk-999', keys['api_key'])
+          assert.equals('hidden123', keys['config.secret'])
+          assert.equals('sk-999', keys['config.api_key'])
+        end
+      end)
+
+      it('should expose nested YAML block key paths', function()
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local lines = {
+          'database:',
+          '  connection:',
+          '    password: secret',
+        }
+        local content = table.concat(lines, '\n')
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+        vim.api.nvim_set_option_value('filetype', 'yaml', { buf = bufnr })
+
+        local result = ts.parse(bufnr, 'yaml', content)
+
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+
+        if result then
+          local by_key = {}
+          for _, v in ipairs(result) do
+            by_key[v.key] = v
+            assert.equals(v.value, content:sub(v.start_index + 1, v.end_index))
+          end
+          assert.equals('secret', by_key['database.connection.password'].value)
+          assert.is_true(by_key['database.connection.password'].is_nested)
         end
       end)
 
@@ -190,8 +245,35 @@ describe('camouflage.treesitter', function()
           assert.is_table(result)
           -- Should only capture 'inner', not 'outer' (which has flow_mapping value)
           assert.equals(1, #result)
-          assert.equals('inner', result[1].key)
+          assert.equals('outer.inner', result[1].key)
           assert.equals('value', result[1].value)
+        end
+      end)
+    end
+
+    if xml_parser_available then
+      it('should expose nested XML element and attribute key paths', function()
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local content =
+          '<settings><database host="localhost" password="dbpass"><password>secret</password></database></settings>'
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { content })
+        vim.api.nvim_set_option_value('filetype', 'xml', { buf = bufnr })
+
+        local result = ts.parse(bufnr, 'xml', content)
+
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+
+        if result then
+          local by_key = {}
+          for _, v in ipairs(result) do
+            by_key[v.key] = v
+            assert.equals(v.value, content:sub(v.start_index + 1, v.end_index))
+          end
+          assert.equals('localhost', by_key['settings.database@host'].value)
+          assert.equals('dbpass', by_key['settings.database@password'].value)
+          assert.equals('secret', by_key['settings.database.password'].value)
+          assert.is_true(by_key['settings.database@password'].is_nested)
+          assert.is_true(by_key['settings.database.password'].is_nested)
         end
       end)
     end


### PR DESCRIPTION
## Description

This PR remediates the review findings around runtime compatibility, autocmd lifecycle, parser registration refresh, and TreeSitter nested key metadata.

Changes included:

- Guard Have I Been Pwned checks on both `vim.system` and `curl` so unsupported Neovim runtimes fail closed instead of calling a missing API.
- Move reveal/follow-cursor runtime autocmds into a dedicated runtime augroup so static autocmd reconfiguration does not orphan follow-cursor state.
- Refresh automatic masking autocmds and re-apply masking to loaded buffers after runtime parser registration or unregistration.
- Derive full nested TreeSitter key paths for JSON, YAML, and XML while preserving value byte offsets.
- Use `parent.path@attribute` for XML attribute keys to avoid collisions with child element paths.
- Update README/help docs and add focused regression coverage for the fixed behaviors.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

## Screenshots (if applicable)

N/A - no visual UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved TreeSitter-based masking for JSON, YAML, and XML, including nested key paths and clearer handling of XML attributes.
  * Runtime parser changes now take effect immediately, without needing to restart Neovim.

* **Bug Fixes**
  * Updated HIBP checks to show a clearer availability message when required tools are missing.
  * Follow-cursor behavior now uses a separate runtime scope to avoid interfering with existing masking setup.

* **Documentation**
  * Clarified HIBP requirements, parser behavior, and supported XML path formatting in the help docs and README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->