### PR TITLE
feat: add workspace secret audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A Neovim plugin that visually masks secrets in `.env`, `.json`, `.yaml`, `.toml`
 - **Multiple styles**: `stars`, `dotted`, `text`, `scramble`
 - **Reveal & Yank**: Temporarily reveal or copy masked values
 - **Follow Cursor Mode**: Auto-reveal current line as you navigate
+- **Workspace Audit**: Scan supported files into quickfix/location list without exposing values
 - **Have I Been Pwned**: Check passwords against breach database (Neovim 0.10+ with `vim.system`, plus `curl`)
 - **JWT Expiry Hints**: Decode `exp` claim and show "expires in 2h" badges
 - **Hot Reload**: Config changes apply immediately
@@ -137,6 +138,11 @@ require('camouflage').setup({
   debounce_ms = 150,
   max_lines = 5000,
 
+  audit = {
+    ignore_patterns = { '.git/**', 'node_modules/**' },
+    destination = 'quickfix', -- 'quickfix' | 'loclist'
+  },
+
   reveal = {
     follow_cursor = false,   -- Auto-reveal current line
   },
@@ -165,6 +171,8 @@ require('camouflage').setup({
 | `:CamouflageFollowCursor` | Toggle follow cursor mode |
 | `:CamouflageStatus` | Show status and masked count |
 | `:CamouflageRefresh` | Refresh decorations |
+| `:CamouflageAudit [path]` | Scan workspace/path and populate quickfix |
+| `:CamouflageAudit! [path]` | Scan workspace/path and populate location list |
 | `:CamouflagePwnedCheck` | Check if value under cursor is pwned |
 | `:CamouflagePwnedCheckBuffer` | Check all values in buffer |
 | `:CamouflageExpiryToggle` | Toggle JWT expiry check on/off |
@@ -172,6 +180,12 @@ require('camouflage').setup({
 | `:CamouflageParsers` | List registered parsers (debug) |
 
 > **[Full commands list](https://github.com/zeybek/camouflage.nvim/wiki/Commands-and-Keymaps)** on the wiki.
+
+## Workspace Audit
+
+`:CamouflageAudit [path]` scans supported files under the current project root or optional path using the same parser registry as live masking. Results are written to quickfix by default; `:CamouflageAudit! [path]` writes to the current window's location list.
+
+Audit results include file, line, column, parser, key, and value length metadata, but never the plaintext value. The audit engine does not run HIBP or any other network check.
 
 ## Supported File Formats
 

--- a/doc/camouflage.txt
+++ b/doc/camouflage.txt
@@ -21,10 +21,11 @@ CONTENTS                                                  *camouflage-contents*
  12. Styles .................................. |camouflage-styles|
  13. Integrations ............................ |camouflage-integrations|
  14. Project Config .......................... |camouflage-project-config|
- 15. Have I Been Pwned ....................... |camouflage-pwned|
- 16. JWT Expiry Hints ........................ |camouflage-expiry|
- 17. Custom Queries .......................... |camouflage-custom-queries|
- 18. Troubleshooting ......................... |camouflage-troubleshooting|
+ 15. Workspace Audit ......................... |camouflage-audit|
+ 16. Have I Been Pwned ....................... |camouflage-pwned|
+ 17. JWT Expiry Hints ........................ |camouflage-expiry|
+ 18. Custom Queries .......................... |camouflage-custom-queries|
+ 19. Troubleshooting ......................... |camouflage-troubleshooting|
 
 ==============================================================================
 INTRODUCTION                                          *camouflage-introduction*
@@ -39,6 +40,7 @@ Features:
 - Nested key support for JSON, YAML, and XML
 - Multiple masking styles: stars, dotted, text, scramble
 - Have I Been Pwned integration for password breach checking
+- Workspace audit into quickfix/location list
 - Buffer-local configuration overrides
 - Telescope and Snacks.nvim preview integration
 - Zero file modification
@@ -179,6 +181,15 @@ Call the setup function with your options: >lua
       },
     },
 
+    -- Workspace audit
+    audit = {
+      ignore_patterns = { '.git/**', 'node_modules/**' },
+      max_files_per_chunk = 50,
+      destination = 'quickfix',   -- 'quickfix' | 'loclist'
+      open = true,                -- Open list after findings
+      notify = true,              -- Notify after completion
+    },
+
     -- Have I Been Pwned (requires Neovim 0.10+ with vim.system, plus curl)
     pwned = {
       enabled = true,             -- Enable the feature
@@ -270,6 +281,16 @@ patterns ~
     File patterns and their associated parsers.
     See |camouflage-formats| for default patterns.
 
+audit ~
+    Type: `table`
+    Workspace audit configuration. See |camouflage-audit|.
+    Fields:
+    - `ignore_patterns`: root-relative or basename globs skipped by audit
+    - `max_files_per_chunk`: async chunk size for command scans
+    - `destination`: `'quickfix'` or `'loclist'`
+    - `open`: open the list after findings are written
+    - `notify`: show completion notifications
+
 ==============================================================================
 COMMANDS                                                  *camouflage-commands*
 
@@ -286,6 +307,13 @@ COMMANDS                                                  *camouflage-commands*
                                                          *:CamouflageRefresh*
 :CamouflageRefresh
   Refresh decorations for all visible buffers.
+
+                                                        *:CamouflageAudit*
+:CamouflageAudit[!] [path]
+  Scan supported files under the current project root or optional [path].
+  Results are written to quickfix by default. Use `!` to write to the current
+  window's location list. Audit entries include file, line, column, parser, and
+  key metadata, but never plaintext values.
 
                                                          *:CamouflageParsers*
 :CamouflageParsers
@@ -631,6 +659,7 @@ Other API functions: ~
 - `camouflage.unregister_parser(name)` — remove a parser (builtins allowed)
 - `camouflage.list_parsers()` — list all registered parsers
 - `camouflage.get_parser(name)` — fetch a parser by name
+- `require('camouflage.audit').run(opts)` — run a redacted workspace audit
 - `:CamouflageParsers` — inspect current registry
 
 Runtime registrations that include `file_patterns` refresh automatic masking
@@ -1006,7 +1035,7 @@ Project config files support most configuration options:
 - style, mask_char, mask_length, hidden_text
 - highlight_group, colors
 - patterns, parsers
-- integrations, yank, reveal, pwned
+- integrations, yank, reveal, audit, pwned
 
 Note: The `project_config` key itself cannot be set in project config files.
 
@@ -1058,6 +1087,54 @@ API ~
   -- Get watcher status
   local watch_status = camouflage.project_config_watch_status()
   -- { enabled = true, backend = 'auto', root_count = 1, roots = {...} }
+<
+
+==============================================================================
+WORKSPACE AUDIT                                           *camouflage-audit*
+
+Workspace audit scans supported files under a project root or explicit path
+using the same parser registry as live masking. It does not create buffers,
+apply extmarks, run hooks, or call network checks.
+
+Commands ~
+                                                 *camouflage-audit-commands*
+:CamouflageAudit [path]      Scan into quickfix
+:CamouflageAudit! [path]     Scan into the current window's location list
+
+If [path] is omitted, camouflage resolves the current project root from the
+nearest `.camouflage.yaml`, nearest `.git` directory, or current working
+directory.
+
+Privacy ~
+                                                  *camouflage-audit-privacy*
+Audit findings include file path, line, column, parser name, key, nested or
+commented metadata, and value length. Plaintext values are stripped before
+results are returned or written to quickfix/location-list. HIBP and other
+network checks are not run during audit.
+
+Configuration ~
+                                                   *camouflage-audit-config*
+>lua
+  require('camouflage').setup({
+    audit = {
+      ignore_patterns = { '.git/**', 'node_modules/**' },
+      max_files_per_chunk = 50,
+      destination = 'quickfix', -- 'quickfix' | 'loclist'
+      open = true,
+      notify = true,
+    },
+  })
+<
+
+`ignore_patterns` are root-relative or basename globs. They are not full
+`.gitignore` semantics; use explicit patterns for directories you want audit
+to skip.
+
+API ~
+                                                      *camouflage-audit-api*
+>lua
+  local result = require('camouflage.audit').run({ root = vim.fn.getcwd() })
+  -- result.findings contains redacted metadata only, never `value`.
 <
 
 ==============================================================================

--- a/lua/camouflage/audit.lua
+++ b/lua/camouflage/audit.lua
@@ -1,0 +1,610 @@
+---@mod camouflage.audit Workspace audit engine
+---@brief [[
+--- Scans files with the existing parser registry and returns redacted findings.
+--- Audit never creates buffers, never applies extmarks, and never runs value
+--- checks such as HIBP. Plaintext parser values are dropped before results are
+--- returned or rendered.
+---@brief ]]
+
+local M = {}
+
+local config = require('camouflage.config')
+local log = require('camouflage.log')
+local parsers = require('camouflage.parsers')
+local position = require('camouflage.position')
+
+-- Compatibility: vim.uv exists in Neovim 0.10+, vim.loop in 0.9.
+local uv = vim.uv or vim.loop
+
+local DEFAULT_CHUNK_SIZE = 50
+
+---@class CamouflageAuditConfig
+---@field ignore_patterns? string[]
+---@field max_files_per_chunk? integer
+---@field destination? string
+---@field open? boolean
+---@field notify? boolean
+
+---@class CamouflageAuditFinding
+---@field filename string
+---@field lnum integer 1-indexed line number
+---@field col integer 1-indexed byte column
+---@field end_col integer|nil 1-indexed end byte column
+---@field key string
+---@field parser string
+---@field is_nested boolean
+---@field is_commented boolean
+---@field is_multiline boolean|nil
+---@field value_length integer
+
+---@class CamouflageAuditError
+---@field filename string
+---@field parser string|nil
+---@field message string
+
+---@class CamouflageAuditResult
+---@field root string
+---@field findings CamouflageAuditFinding[]
+---@field errors CamouflageAuditError[]
+---@field stats table
+---@field cancelled boolean
+
+---@class CamouflageAuditHandle
+---@field result CamouflageAuditResult|nil
+---@field cancel fun()
+---@field is_cancelled fun(): boolean
+
+---@param path string
+---@return string
+local function normalize_path(path)
+  local normalized = vim.fn.fnamemodify(path, ':p'):gsub('\\', '/')
+  if #normalized > 1 then
+    normalized = normalized:gsub('/+$', '')
+  end
+  return normalized
+end
+
+---@param path string
+---@return string
+local function basename(path)
+  return vim.fn.fnamemodify(path, ':t')
+end
+
+---@param path string
+---@param root string
+---@return string
+local function relative_path(path, root)
+  local rel = path:gsub('\\', '/')
+  local normalized_root = root:gsub('\\', '/'):gsub('/+$', '')
+  if rel == normalized_root then
+    return basename(rel)
+  end
+  if rel:sub(1, #normalized_root + 1) == normalized_root .. '/' then
+    rel = rel:sub(#normalized_root + 2)
+  end
+  return rel
+end
+
+---@param glob string
+---@return string
+local function glob_to_pattern(glob)
+  local token = '\1'
+  local escaped = glob:gsub('\\', '/'):gsub('%*%*', token)
+  escaped = escaped:gsub('([%^%$%(%)%%%.%[%]%+%-])', '%%%1')
+  escaped = escaped:gsub('%*', '[^/]*'):gsub('%?', '[^/]')
+  escaped = escaped:gsub(token, '.*')
+  return '^' .. escaped .. '$'
+end
+
+---@param text string
+---@param glob string
+---@return boolean
+local function glob_matches(text, glob)
+  return text:gsub('\\', '/'):match(glob_to_pattern(glob)) ~= nil
+end
+
+---@param path string
+---@param ignore_patterns string[]
+---@return boolean
+local function is_ignored(path, ignore_patterns)
+  local normalized = path:gsub('\\', '/')
+  local name = basename(normalized)
+
+  for _, pattern in ipairs(ignore_patterns) do
+    if pattern:find('/', 1, true) then
+      if glob_matches(normalized, pattern) then
+        return true
+      end
+    elseif parsers.match_pattern(name, pattern) or glob_matches(normalized, pattern) then
+      return true
+    end
+  end
+
+  return false
+end
+
+---@param opts table|nil
+---@return table
+local function audit_config(opts)
+  local cfg = config.get().audit or {}
+  local audit_opts = opts or {}
+  local merged = vim.tbl_deep_extend('force', {
+    ignore_patterns = { '.git', '.git/**', 'node_modules', 'node_modules/**' },
+    max_files_per_chunk = DEFAULT_CHUNK_SIZE,
+    destination = 'quickfix',
+    open = true,
+    notify = true,
+  }, cfg)
+
+  if audit_opts.ignore_patterns then
+    merged.ignore_patterns = audit_opts.ignore_patterns
+  end
+  if audit_opts.max_files_per_chunk then
+    merged.max_files_per_chunk = audit_opts.max_files_per_chunk
+  end
+  if audit_opts.destination then
+    merged.destination = audit_opts.destination
+  end
+  if audit_opts.open ~= nil then
+    merged.open = audit_opts.open
+  end
+  if audit_opts.notify ~= nil then
+    merged.notify = audit_opts.notify
+  end
+
+  return merged
+end
+
+---@param start_dir string
+---@return string
+local function resolve_root_from_dir(start_dir)
+  local cfg = config.get().project_config or {}
+  local project_config_filename = cfg.filename or '.camouflage.yaml'
+  local project_file = vim.fn.findfile(project_config_filename, start_dir .. ';')
+  if project_file ~= '' then
+    return normalize_path(vim.fn.fnamemodify(project_file, ':h'))
+  end
+
+  local git_dir = vim.fn.finddir('.git', start_dir .. ';')
+  if git_dir ~= '' then
+    return normalize_path(vim.fn.fnamemodify(git_dir, ':h'))
+  end
+
+  return normalize_path(vim.fn.getcwd())
+end
+
+---@param bufnr number|nil
+---@return string
+function M.resolve_root(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+    local name = vim.api.nvim_buf_get_name(bufnr)
+    if name ~= '' then
+      return resolve_root_from_dir(vim.fn.fnamemodify(name, ':p:h'))
+    end
+  end
+  return resolve_root_from_dir(vim.fn.getcwd())
+end
+
+---@param opts table
+---@return string root
+---@return string target
+local function resolve_target(opts)
+  local raw = opts.path or opts.root
+  if not raw or raw == '' then
+    local root = M.resolve_root(opts.bufnr)
+    return root, root
+  end
+
+  local target = normalize_path(raw)
+  local stat = uv and uv.fs_stat and uv.fs_stat(target) or nil
+  if stat and stat.type == 'file' then
+    return normalize_path(vim.fn.fnamemodify(target, ':h')), target
+  end
+
+  return target, target
+end
+
+---@param root string
+---@return CamouflageAuditResult
+local function new_result(root)
+  return {
+    root = root,
+    findings = {},
+    errors = {},
+    cancelled = false,
+    stats = {
+      files_seen = 0,
+      files_supported = 0,
+      files_scanned = 0,
+      files_skipped = 0,
+      findings = 0,
+      elapsed_ms = 0,
+    },
+  }
+end
+
+---@param result CamouflageAuditResult
+---@param filename string
+---@param parser_name string|nil
+---@param message string
+local function add_error(result, filename, parser_name, message)
+  table.insert(result.errors, {
+    filename = filename,
+    parser = parser_name,
+    message = message,
+  })
+end
+
+---@param path string
+---@param root string
+---@param cfg table
+---@param result CamouflageAuditResult
+---@param files string[]
+local function collect_files(path, root, cfg, result, files)
+  local stat = uv and uv.fs_lstat and uv.fs_lstat(path) or (uv and uv.fs_stat and uv.fs_stat(path))
+  if not stat then
+    add_error(result, path, nil, 'failed to stat path')
+    return
+  end
+
+  local rel = relative_path(path, root)
+  if is_ignored(rel, cfg.ignore_patterns or {}) then
+    result.stats.files_skipped = result.stats.files_skipped + 1
+    return
+  end
+
+  if stat.type == 'file' then
+    result.stats.files_seen = result.stats.files_seen + 1
+    table.insert(files, path)
+    return
+  end
+
+  if stat.type ~= 'directory' then
+    result.stats.files_skipped = result.stats.files_skipped + 1
+    return
+  end
+
+  local scanner = uv and uv.fs_scandir and uv.fs_scandir(path) or nil
+  if not scanner then
+    add_error(result, path, nil, 'failed to scan directory')
+    return
+  end
+
+  while true do
+    local name, entry_type = uv.fs_scandir_next(scanner)
+    if not name then
+      break
+    end
+    if name ~= '.' and name ~= '..' then
+      local child = path .. '/' .. name
+      if entry_type == 'link' then
+        result.stats.files_skipped = result.stats.files_skipped + 1
+      else
+        collect_files(child, root, cfg, result, files)
+      end
+    end
+  end
+end
+
+---@param target string
+---@return table
+local function new_discovery(target)
+  return {
+    done = false,
+    stack = {
+      { kind = 'path', path = target },
+    },
+  }
+end
+
+---@param state table
+---@param root string
+---@param cfg table
+---@param result CamouflageAuditResult
+---@param files string[]
+local function discover_one(state, root, cfg, result, files)
+  local frame = table.remove(state.stack)
+  if not frame then
+    state.done = true
+    return
+  end
+
+  if frame.kind == 'scanner' then
+    local name, entry_type = uv.fs_scandir_next(frame.scanner)
+    if not name then
+      return
+    end
+
+    table.insert(state.stack, frame)
+    if name == '.' or name == '..' then
+      return
+    end
+
+    if entry_type == 'link' then
+      result.stats.files_skipped = result.stats.files_skipped + 1
+    else
+      table.insert(state.stack, { kind = 'path', path = frame.path .. '/' .. name })
+    end
+    return
+  end
+
+  local path = frame.path
+  local stat = uv and uv.fs_lstat and uv.fs_lstat(path) or (uv and uv.fs_stat and uv.fs_stat(path))
+  if not stat then
+    add_error(result, path, nil, 'failed to stat path')
+    return
+  end
+
+  local rel = relative_path(path, root)
+  if is_ignored(rel, cfg.ignore_patterns or {}) then
+    result.stats.files_skipped = result.stats.files_skipped + 1
+    return
+  end
+
+  if stat.type == 'file' then
+    result.stats.files_seen = result.stats.files_seen + 1
+    table.insert(files, path)
+    return
+  end
+
+  if stat.type ~= 'directory' then
+    result.stats.files_skipped = result.stats.files_skipped + 1
+    return
+  end
+
+  local scanner = uv and uv.fs_scandir and uv.fs_scandir(path) or nil
+  if not scanner then
+    add_error(result, path, nil, 'failed to scan directory')
+    return
+  end
+
+  table.insert(state.stack, { kind = 'scanner', path = path, scanner = scanner })
+end
+
+---@param result CamouflageAuditResult
+---@param var ParsedVariable
+---@param filename string
+---@param parser_name string
+---@param lines string[]
+---@param line_offsets number[]
+local function add_finding(result, var, filename, parser_name, lines, line_offsets)
+  if type(var) ~= 'table' or not var.key or not var.value then
+    return
+  end
+
+  local start_pos = position.index_to_position(0, var.start_index or 0, lines, line_offsets)
+  local end_pos =
+    position.index_to_position(0, var.end_index or var.start_index or 0, lines, line_offsets)
+  local lnum = (start_pos and start_pos.row + 1) or ((var.line_number or 0) + 1)
+  local col = start_pos and (start_pos.col + 1) or 1
+  local end_col = end_pos and (end_pos.col + 1) or nil
+
+  table.insert(result.findings, {
+    filename = filename,
+    lnum = lnum,
+    col = col,
+    end_col = end_col,
+    key = tostring(var.key),
+    parser = parser_name,
+    is_nested = var.is_nested == true,
+    is_commented = var.is_commented == true,
+    is_multiline = var.is_multiline == true or nil,
+    value_length = #tostring(var.value),
+  })
+  result.stats.findings = result.stats.findings + 1
+end
+
+---@param result CamouflageAuditResult
+---@param filename string
+---@param cfg table
+local function process_file(result, filename, cfg)
+  local parser, parser_name = parsers.find_parser_for_file(filename)
+  if not parser then
+    result.stats.files_skipped = result.stats.files_skipped + 1
+    return
+  end
+  result.stats.files_supported = result.stats.files_supported + 1
+
+  local ok_read, lines = pcall(vim.fn.readfile, filename)
+  if not ok_read or type(lines) ~= 'table' then
+    add_error(result, filename, parser_name, 'failed to read file')
+    return
+  end
+
+  local max_lines = config.get().max_lines
+  if max_lines and #lines > max_lines then
+    result.stats.files_skipped = result.stats.files_skipped + 1
+    return
+  end
+
+  local content = table.concat(lines, '\n')
+  local ok_parse, variables = pcall(parser.parse, content, nil)
+  if not ok_parse then
+    add_error(result, filename, parser_name, 'parser failed')
+    return
+  end
+  if type(variables) ~= 'table' then
+    add_error(result, filename, parser_name, 'parser returned invalid result')
+    return
+  end
+
+  result.stats.files_scanned = result.stats.files_scanned + 1
+  local line_offsets = position.compute_line_offsets(lines)
+  for _, var in ipairs(variables) do
+    add_finding(result, var, filename, parser_name, lines, line_offsets)
+  end
+end
+
+---@param result CamouflageAuditResult
+---@param started number
+local function finish_result(result, started)
+  result.stats.elapsed_ms = math.max(0, math.floor((vim.loop.hrtime() - started) / 1000000))
+  log.debug(
+    'audit root=%s seen=%d supported=%d scanned=%d skipped=%d findings=%d errors=%d elapsed_ms=%d',
+    result.root,
+    result.stats.files_seen,
+    result.stats.files_supported,
+    result.stats.files_scanned,
+    result.stats.files_skipped,
+    result.stats.findings,
+    #result.errors,
+    result.stats.elapsed_ms
+  )
+end
+
+---@param opts table|nil
+---@return CamouflageAuditResult
+function M.run_sync(opts)
+  opts = opts or {}
+  local cfg = audit_config(opts)
+  local root, target = resolve_target(opts)
+  local result = new_result(root)
+  local started = vim.loop.hrtime()
+  local files = {}
+
+  collect_files(target, root, cfg, result, files)
+  for _, filename in ipairs(files) do
+    process_file(result, filename, cfg)
+  end
+
+  finish_result(result, started)
+  return result
+end
+
+---@param opts table|nil
+---@return CamouflageAuditHandle
+function M.run_async(opts)
+  opts = opts or {}
+  local cfg = audit_config(opts)
+  local root, target = resolve_target(opts)
+  local result = new_result(root)
+  local started = vim.loop.hrtime()
+  local files = {}
+  local discovery = new_discovery(target)
+  local index = 1
+  local cancelled = false
+  local chunk_size = math.max(1, tonumber(cfg.max_files_per_chunk) or DEFAULT_CHUNK_SIZE)
+
+  local handle = {
+    result = nil,
+  }
+
+  function handle.cancel()
+    cancelled = true
+  end
+
+  function handle.is_cancelled()
+    return cancelled
+  end
+
+  local function complete()
+    result.cancelled = cancelled
+    finish_result(result, started)
+    handle.result = result
+    if opts.on_complete then
+      opts.on_complete(result)
+    end
+  end
+
+  local function step()
+    if cancelled then
+      complete()
+      return
+    end
+
+    local phase = discovery.done and 'scan' or 'discover'
+    local processed = 0
+
+    while not discovery.done and processed < chunk_size do
+      discover_one(discovery, root, cfg, result, files)
+      processed = processed + 1
+    end
+
+    while discovery.done and index <= #files and processed < chunk_size do
+      process_file(result, files[index], cfg)
+      index = index + 1
+      processed = processed + 1
+    end
+
+    if opts.on_progress then
+      opts.on_progress({
+        phase = phase,
+        root = root,
+        files_total = #files,
+        files_done = math.min(index - 1, #files),
+        files_discovered = #files,
+        files_scanned = result.stats.files_scanned,
+        findings = result.stats.findings,
+        errors = #result.errors,
+      })
+    end
+
+    if discovery.done and index > #files then
+      complete()
+      return
+    end
+
+    vim.schedule(step)
+  end
+
+  vim.schedule(step)
+  return handle
+end
+
+---@param opts table|nil
+---@return CamouflageAuditResult|CamouflageAuditHandle
+function M.run(opts)
+  opts = opts or {}
+  if opts.async or opts.on_complete then
+    return M.run_async(opts)
+  end
+  return M.run_sync(opts)
+end
+
+---@param finding CamouflageAuditFinding
+---@return string
+local function finding_text(finding)
+  return string.format('[%s] %s', finding.parser or 'unknown', finding.key or 'unknown')
+end
+
+---@param result CamouflageAuditResult
+---@return table[]
+function M.to_quickfix_items(result)
+  local items = {}
+  for _, finding in ipairs(result.findings or {}) do
+    table.insert(items, {
+      filename = finding.filename,
+      lnum = finding.lnum,
+      col = finding.col,
+      end_col = finding.end_col,
+      text = finding_text(finding),
+      type = 'I',
+    })
+  end
+  return items
+end
+
+---@param result CamouflageAuditResult
+---@param opts table|nil
+function M.set_list(result, opts)
+  opts = opts or {}
+  local cfg = audit_config(opts)
+  local destination = opts.destination or cfg.destination or 'quickfix'
+  local items = M.to_quickfix_items(result)
+  local title = string.format('Camouflage Audit: %s', result.root)
+
+  if destination == 'loclist' or destination == 'location' then
+    vim.fn.setloclist(0, {}, 'r', { title = title, items = items })
+    if cfg.open ~= false and #items > 0 then
+      vim.cmd('lopen')
+    end
+  else
+    vim.fn.setqflist({}, 'r', { title = title, items = items })
+    if cfg.open ~= false and #items > 0 then
+      vim.cmd('copen')
+    end
+  end
+end
+
+return M

--- a/lua/camouflage/commands.lua
+++ b/lua/camouflage/commands.lua
@@ -69,6 +69,42 @@ function M.setup()
     vim.notify('[camouflage] refreshed', vim.log.levels.INFO)
   end, { desc = 'Refresh Camouflage decorations' })
 
+  vim.api.nvim_create_user_command('CamouflageAudit', function(opts)
+    local audit = require('camouflage.audit')
+    local cfg = require('camouflage.config').get().audit or {}
+    local destination = opts.bang and 'loclist' or (cfg.destination or 'quickfix')
+
+    audit.run({
+      path = opts.args ~= '' and opts.args or nil,
+      async = true,
+      destination = destination,
+      on_complete = function(result)
+        audit.set_list(result, {
+          destination = destination,
+          open = cfg.open ~= false,
+        })
+
+        if cfg.notify ~= false then
+          if #result.findings == 0 then
+            vim.notify('[camouflage] audit found no masked values', vim.log.levels.INFO)
+          else
+            local suffix = #result.errors > 0 and string.format(' (%d errors)', #result.errors)
+              or ''
+            vim.notify(
+              string.format('[camouflage] audit found %d masked values%s', #result.findings, suffix),
+              vim.log.levels.INFO
+            )
+          end
+        end
+      end,
+    })
+  end, {
+    desc = 'Audit workspace for masked values',
+    bang = true,
+    nargs = '?',
+    complete = 'file',
+  })
+
   vim.api.nvim_create_user_command('CamouflageStatus', function()
     local camouflage = require('camouflage')
     local state = require('camouflage.state')

--- a/lua/camouflage/config.lua
+++ b/lua/camouflage/config.lua
@@ -102,6 +102,13 @@ local M = {}
 ---@field separator? string Text inserted between adjacent badges (default: ' ')
 ---@field separator_hl? string Highlight for the separator (default: 'Comment')
 
+---@class CamouflageAuditConfig
+---@field ignore_patterns? string[] Root-relative globs or basename globs skipped by workspace audit
+---@field max_files_per_chunk? integer Number of discovered files processed per scheduled async chunk
+---@field destination? string "quickfix" | "loclist" (default: "quickfix")
+---@field open? boolean Open quickfix/location-list after findings are written
+---@field notify? boolean Show audit completion notifications
+
 ---@class CamouflageChecksConfig
 ---@field badges? CamouflageBadgesConfig
 ---@field pwned? CamouflagePwnedConfig
@@ -139,6 +146,7 @@ local M = {}
 ---@field pwned? CamouflagePwnedConfig Pwned passwords check configuration
 ---@field custom_patterns? CamouflageCustomPatternConfig[] Custom patterns for unsupported file types
 ---@field project_config? CamouflageProjectConfigLoaderConfig Repo-level project config loading
+---@field audit? CamouflageAuditConfig Workspace audit configuration
 ---@field checks? CamouflageChecksConfig Per-check configuration (pwned, expiry, ...)
 
 ---@type CamouflageConfig
@@ -217,6 +225,13 @@ M.defaults = {
     line_hl = 'CamouflagePwned',
   },
   custom_patterns = {},
+  audit = {
+    ignore_patterns = { '.git', '.git/**', 'node_modules', 'node_modules/**' },
+    max_files_per_chunk = 50,
+    destination = 'quickfix',
+    open = true,
+    notify = true,
+  },
   checks = {
     badges = {
       position = 'right_align',

--- a/lua/camouflage/templates/project_config.yaml
+++ b/lua/camouflage/templates/project_config.yaml
@@ -143,6 +143,27 @@ integrations:
     disable_in_masked: true
 
 # =============================================================================
+# WORKSPACE AUDIT
+# =============================================================================
+
+# Configuration for :CamouflageAudit
+audit:
+  # Root-relative or basename globs skipped by workspace audit
+  ignore_patterns: ['.git', '.git/**', 'node_modules', 'node_modules/**']
+
+  # Number of files processed per scheduled command chunk
+  max_files_per_chunk: 50
+
+  # Default list target: 'quickfix' or 'loclist'
+  destination: quickfix
+
+  # Open quickfix/location-list after findings are written
+  open: true
+
+  # Show audit completion notifications
+  notify: true
+
+# =============================================================================
 # YANK (COPY) FEATURE
 # =============================================================================
 

--- a/schemas/camouflage-project-config.schema.json
+++ b/schemas/camouflage-project-config.schema.json
@@ -218,6 +218,41 @@
         }
       }
     },
+    "audit": {
+      "type": "object",
+      "description": "Workspace audit configuration",
+      "additionalProperties": false,
+      "properties": {
+        "ignore_patterns": {
+          "type": "array",
+          "description": "Root-relative or basename globs skipped by workspace audit",
+          "items": {
+            "type": "string"
+          }
+        },
+        "max_files_per_chunk": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of files processed per scheduled audit chunk"
+        },
+        "destination": {
+          "type": "string",
+          "enum": [
+            "quickfix",
+            "loclist"
+          ],
+          "description": "Default list target for audit command results"
+        },
+        "open": {
+          "type": "boolean",
+          "description": "Open quickfix/location-list after findings are written"
+        },
+        "notify": {
+          "type": "boolean",
+          "description": "Show audit completion notifications"
+        }
+      }
+    },
     "yank": {
       "type": "object",
       "description": "Configuration for copying unmasked values",

--- a/tests/camouflage/audit_spec.lua
+++ b/tests/camouflage/audit_spec.lua
@@ -1,0 +1,280 @@
+describe('camouflage.audit', function()
+  local plugin_root = vim.fn.getcwd()
+  local original_cwd
+
+  package.path = plugin_root .. '/lua/?.lua;' .. plugin_root .. '/lua/?/init.lua;' .. package.path
+
+  local function clear_camouflage_modules()
+    for name, _ in pairs(package.loaded) do
+      if name:match('^camouflage') then
+        package.loaded[name] = nil
+      end
+    end
+  end
+
+  local function writefile(path, lines)
+    vim.fn.mkdir(vim.fn.fnamemodify(path, ':h'), 'p')
+    vim.fn.writefile(lines, path)
+  end
+
+  local function setup_in_dir(dir, opts)
+    opts = opts or {}
+    clear_camouflage_modules()
+    local camouflage = require('camouflage')
+    local audit = require('camouflage.audit')
+    vim.cmd('cd ' .. vim.fn.fnameescape(dir))
+    local base = {
+      project_config = {
+        watch_enabled = false,
+      },
+      audit = {
+        open = false,
+        notify = false,
+      },
+    }
+    camouflage.setup(vim.tbl_deep_extend('force', base, opts))
+    return audit, camouflage
+  end
+
+  local function inspect_has(value, needle)
+    return vim.inspect(value):find(needle, 1, true) ~= nil
+  end
+
+  before_each(function()
+    original_cwd = vim.fn.getcwd()
+    vim.fn.setqflist({}, 'r')
+    vim.fn.setloclist(0, {}, 'r')
+  end)
+
+  after_each(function()
+    pcall(vim.cmd, 'cclose')
+    pcall(vim.cmd, 'lclose')
+    vim.fn.setqflist({}, 'r')
+    vim.fn.setloclist(0, {}, 'r')
+    vim.cmd('cd ' .. vim.fn.fnameescape(original_cwd))
+  end)
+
+  it('scans supported files and returns redacted findings', function()
+    local dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    writefile(dir .. '/.camouflage.yaml', { 'version: 1' })
+    writefile(dir .. '/.env', { 'API_KEY=env-secret-should-not-return' })
+    writefile(dir .. '/config.json', { '{"TOKEN": "json-secret-should-not-return"}' })
+    writefile(dir .. '/notes.txt', { 'PASSWORD=unsupported-secret' })
+
+    local audit = setup_in_dir(dir)
+    local result = audit.run({ root = dir })
+
+    assert.equals(2, #result.findings)
+    assert.equals(0, #result.errors)
+    for _, finding in ipairs(result.findings) do
+      assert.is_nil(finding.value)
+      assert.is_string(finding.filename)
+      assert.is_number(finding.lnum)
+      assert.is_number(finding.col)
+      assert.is_string(finding.parser)
+      assert.is_number(finding.value_length)
+    end
+    assert.is_false(inspect_has(result, 'env-secret-should-not-return'))
+    assert.is_false(inspect_has(result, 'json-secret-should-not-return'))
+    assert.is_false(inspect_has(result, 'unsupported-secret'))
+  end)
+
+  it('uses runtime registered parsers', function()
+    local dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    writefile(dir .. '/app.kdl', { 'token "runtime-secret-should-not-return"' })
+
+    local audit, camouflage = setup_in_dir(dir)
+    camouflage.register_parser({
+      name = 'kdl',
+      file_patterns = { '*.kdl' },
+      parser = {
+        parse = function()
+          return {
+            {
+              key = 'token',
+              value = 'runtime-secret-should-not-return',
+              start_index = 7,
+              end_index = 39,
+              line_number = 0,
+              is_nested = false,
+              is_commented = false,
+            },
+          }
+        end,
+      },
+    })
+
+    local result = audit.run({ root = dir })
+
+    assert.equals(1, #result.findings)
+    assert.equals('kdl', result.findings[1].parser)
+    assert.equals('token', result.findings[1].key)
+    assert.is_false(inspect_has(result, 'runtime-secret-should-not-return'))
+  end)
+
+  it('uses custom pattern configuration', function()
+    local dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    writefile(dir .. '/app.secret', { 'SECRET: custom-secret-should-not-return' })
+
+    local audit = setup_in_dir(dir, {
+      custom_patterns = {
+        {
+          file_pattern = '*.secret',
+          pattern = 'SECRET:%s*(.+)',
+          value_capture = 1,
+        },
+      },
+    })
+
+    local result = audit.run({ root = dir })
+
+    assert.equals(1, #result.findings)
+    assert.equals('custom', result.findings[1].parser)
+    assert.equals('custom_1', result.findings[1].key)
+    assert.is_false(inspect_has(result, 'custom-secret-should-not-return'))
+  end)
+
+  it('skips project config, unsupported files, oversized files, and ignored paths', function()
+    local dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    writefile(dir .. '/.camouflage.yaml', { 'version: 1', 'hidden_text: project-config-value' })
+    writefile(dir .. '/keep.env', { 'KEEP=mask-me' })
+    writefile(dir .. '/big.env', { 'ONE=1', 'TWO=2' })
+    writefile(dir .. '/ignored/skip.env', { 'SKIP=ignore-me' })
+    writefile(dir .. '/notes.txt', { 'NOTE=unsupported' })
+
+    local audit = setup_in_dir(dir, {
+      max_lines = 1,
+      audit = {
+        ignore_patterns = { 'ignored', 'ignored/**' },
+      },
+    })
+
+    local result = audit.run({ root = dir })
+
+    assert.equals(1, #result.findings)
+    assert.equals('KEEP', result.findings[1].key)
+    assert.is_false(inspect_has(result, 'project-config-value'))
+    assert.is_false(inspect_has(result, 'ignore-me'))
+  end)
+
+  it('continues after parser errors without returning parser error plaintext', function()
+    local dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    writefile(dir .. '/ok.env', { 'OK=still-found' })
+    writefile(dir .. '/bad.err', { 'BAD=parser-error-secret' })
+
+    local audit, camouflage = setup_in_dir(dir)
+    camouflage.register_parser({
+      name = 'broken',
+      file_patterns = { '*.err' },
+      parser = {
+        parse = function()
+          error('parser saw parser-error-secret')
+        end,
+      },
+    })
+
+    local result = audit.run({ root = dir })
+
+    assert.equals(1, #result.findings)
+    assert.equals(1, #result.errors)
+    assert.equals('broken', result.errors[1].parser)
+    assert.equals('parser failed', result.errors[1].message)
+    assert.is_false(inspect_has(result, 'parser-error-secret'))
+  end)
+
+  it('runs asynchronously in chunks and supports cancellation', function()
+    local dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    for i = 1, 5 do
+      writefile(dir .. '/file' .. i .. '.env', { 'KEY' .. i .. '=value' .. i })
+    end
+
+    local audit = setup_in_dir(dir)
+    local done = false
+    local final_result
+    local progress_count = 0
+    local handle
+
+    handle = audit.run({
+      root = dir,
+      async = true,
+      max_files_per_chunk = 1,
+      on_progress = function(progress)
+        progress_count = progress_count + 1
+        if progress.files_done >= 1 then
+          handle.cancel()
+        end
+      end,
+      on_complete = function(result)
+        final_result = result
+        done = true
+      end,
+    })
+
+    vim.wait(1000, function()
+      return done
+    end)
+
+    assert.is_true(done)
+    assert.is_true(progress_count > 0)
+    assert.is_true(final_result.cancelled)
+    assert.is_true(final_result.stats.files_scanned < final_result.stats.files_seen)
+  end)
+
+  it('writes quickfix entries without values and clears stale entries on empty results', function()
+    local dir = vim.fn.tempname()
+    local empty_dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    vim.fn.mkdir(empty_dir, 'p')
+    writefile(dir .. '/.env', { 'API_KEY=qf-secret-should-not-return' })
+
+    local audit = setup_in_dir(dir)
+    local result = audit.run({ root = dir })
+    audit.set_list(result, { destination = 'quickfix', open = false })
+
+    local items = vim.fn.getqflist()
+    assert.equals(1, #items)
+    assert.matches('%[env%] API_KEY', items[1].text)
+    assert.is_false(inspect_has(items, 'qf-secret-should-not-return'))
+
+    local empty_result = audit.run({ root = empty_dir })
+    audit.set_list(empty_result, { destination = 'quickfix', open = false })
+
+    assert.equals(0, #vim.fn.getqflist())
+  end)
+
+  it('CamouflageAudit populates quickfix by default and bang populates location list', function()
+    local dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    writefile(dir .. '/.env', { 'API_KEY=command-secret-should-not-return' })
+
+    setup_in_dir(dir)
+
+    assert.has_no.errors(function()
+      vim.cmd('CamouflageAudit ' .. vim.fn.fnameescape(dir))
+    end)
+    vim.wait(1000, function()
+      return #vim.fn.getqflist() > 0
+    end)
+
+    local qf = vim.fn.getqflist()
+    assert.equals(1, #qf)
+    assert.is_false(inspect_has(qf, 'command-secret-should-not-return'))
+
+    assert.has_no.errors(function()
+      vim.cmd('CamouflageAudit! ' .. vim.fn.fnameescape(dir))
+    end)
+    vim.wait(1000, function()
+      return #vim.fn.getloclist(0) > 0
+    end)
+
+    local loc = vim.fn.getloclist(0)
+    assert.equals(1, #loc)
+    assert.is_false(inspect_has(loc, 'command-secret-should-not-return'))
+  end)
+end)

--- a/tests/camouflage/commands_spec.lua
+++ b/tests/camouflage/commands_spec.lua
@@ -27,6 +27,11 @@ describe('camouflage.commands', function()
     assert.is_not_nil(commands['CamouflageStatus'])
   end)
 
+  it('should create CamouflageAudit command', function()
+    local commands = vim.api.nvim_get_commands({})
+    assert.is_not_nil(commands['CamouflageAudit'])
+  end)
+
   it('should create CamouflageYank command', function()
     local commands = vim.api.nvim_get_commands({})
     assert.is_not_nil(commands['CamouflageYank'])

--- a/tests/camouflage/project_config_spec.lua
+++ b/tests/camouflage/project_config_spec.lua
@@ -1,7 +1,10 @@
 describe('camouflage.project_config', function()
+  local plugin_root = vim.fn.getcwd()
   local project_config
   local config
   local original_cwd
+
+  package.path = plugin_root .. '/lua/?.lua;' .. plugin_root .. '/lua/?/init.lua;' .. package.path
 
   local function clear_camouflage_modules()
     for name, _ in pairs(package.loaded) do
@@ -159,5 +162,29 @@ describe('camouflage.project_config', function()
     assert.equals(2, #patterns)
     assert.equals('json', patterns[1].parser)
     assert.equals('yaml', patterns[2].parser)
+  end)
+
+  it('should load audit configuration', function()
+    local dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    vim.fn.writefile({
+      'version: 1',
+      'audit:',
+      "  ignore_patterns: ['tmp/**', 'fixtures/**']",
+      '  max_files_per_chunk: 2',
+      '  destination: loclist',
+      '  open: false',
+      '  notify: false',
+    }, dir .. '/.camouflage.yaml')
+    vim.cmd('cd ' .. vim.fn.fnameescape(dir))
+
+    config.setup()
+    local audit = config.get().audit
+
+    assert.same({ 'tmp/**', 'fixtures/**' }, audit.ignore_patterns)
+    assert.equals(2, audit.max_files_per_chunk)
+    assert.equals('loclist', audit.destination)
+    assert.is_false(audit.open)
+    assert.is_false(audit.notify)
   end)
 end)


### PR DESCRIPTION
## Description

Adds a workspace audit flow that scans configured repository files with the existing parser registry and reports detected masked variables through Neovim diagnostics-style outputs. The change includes the audit engine, user commands, project configuration defaults, JSON schema updates, help docs, README coverage, and focused regression tests.

The feature is intended to make camouflage.nvim useful beyond the current buffer by letting users audit a workspace or run the same check in headless CI mode.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format-check`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

## Screenshots (if applicable)

N/A

## Validation

- `make format-check`
- `make lint`
- `make test`