### PR TITLE
test: relax policy performance budget

### DIFF
--- a/tests/camouflage/policy_spec.lua
+++ b/tests/camouflage/policy_spec.lua
@@ -245,40 +245,48 @@ describe('camouflage.policy', function()
       assert.is_false(vim.inspect(result):find('secret', 1, true) ~= nil)
     end)
 
-    it('classifies one thousand variables against one hundred rules quickly enough', function()
-      local rules = {}
-      for i = 1, 100 do
-        rules[i] = {
-          id = 'rule-' .. i,
-          action = i == 100 and 'ignore' or 'mask',
-          key = { '^RULE_' .. i .. '$' },
-        }
-      end
+    it(
+      'classifies one thousand variables against one hundred rules without pathological slowdown',
+      function()
+        local rules = {}
+        for i = 1, 100 do
+          rules[i] = {
+            id = 'rule-' .. i,
+            action = i == 100 and 'ignore' or 'mask',
+            key = { '^RULE_' .. i .. '$' },
+          }
+        end
 
-      local variables = {}
-      for i = 1, 1000 do
-        variables[i] = parsed_var('RULE_100', 'token-value-' .. i)
-      end
+        local variables = {}
+        for i = 1, 1000 do
+          variables[i] = parsed_var('RULE_100', 'token-value-' .. i)
+        end
 
-      local start = (vim.uv or vim.loop).hrtime()
-      local filtered = policy.filter_variables({
-        filename = '/repo/app.env',
-        root = '/repo',
-        parser_name = 'env',
-        variables = variables,
-        config = {
-          policy = {
-            rules = rules,
+        local start = (vim.uv or vim.loop).hrtime()
+        local filtered = policy.filter_variables({
+          filename = '/repo/app.env',
+          root = '/repo',
+          parser_name = 'env',
+          variables = variables,
+          config = {
+            policy = {
+              rules = rules,
+            },
           },
-        },
-      })
-      local elapsed_ms = ((vim.uv or vim.loop).hrtime() - start) / 1000000
+        })
+        local elapsed_ms = ((vim.uv or vim.loop).hrtime() - start) / 1000000
+        local budget_ms = 100
 
-      assert.equals(0, #filtered)
-      assert.is_true(
-        elapsed_ms < 15,
-        string.format('expected 100 rules x 1000 variables under 15ms, got %.2fms', elapsed_ms)
-      )
-    end)
+        assert.equals(0, #filtered)
+        assert.is_true(
+          elapsed_ms < budget_ms,
+          string.format(
+            'expected 100 rules x 1000 variables under %dms, got %.2fms',
+            budget_ms,
+            elapsed_ms
+          )
+        )
+      end
+    )
   end)
 end)


### PR DESCRIPTION
## Description

This PR relaxes the policy performance regression test that was failing on GitHub Actions due to normal runner variance. The test still exercises 1,000 variables against 100 rules and verifies the ignore-rule path returns no variables, but it now treats the timing assertion as a pathological-slowdown guard with a 100ms budget.

Root cause: the previous 15ms ceiling was too tight for CI. Recent failed runs measured the same workload at roughly 23-30ms across supported Neovim versions, so the assertion could fail even though the policy logic was behaving correctly.

Validation performed:

- `make format`
- `make format-check`
- `make lint`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/policy_spec.lua"`
- `make test`
- `git diff --check`

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

## Screenshots (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a performance check for variable filtering to allow a higher execution time threshold.
  * Improved the test failure message to include the measured elapsed time for easier debugging.
  * Refined the formatting of the test case without changing the expected result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->