### PR TITLE
feat: add public check API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A Neovim plugin that visually masks secrets in `.env`, `.json`, `.yaml`, `.toml`
 - **Workspace Audit**: Scan supported files into quickfix/location list without exposing values
 - **Rule-Based Policy**: Data-only ignore/force-mask rules for paths, parsers, keys, metadata, and safe value shapes
 - **Weak Secret Check**: Offline badges for obvious defaults, placeholders, short values, repeated values, and low-entropy tokens
+- **Custom Check API**: Register trusted Lua checks that render through the shared badge pipeline
 - **Have I Been Pwned**: Check passwords against breach database (Neovim 0.10+ with `vim.system`, plus `curl`)
 - **JWT Expiry Hints**: Decode `exp` claim and show "expires in 2h" badges
 - **Hot Reload**: Config changes apply immediately
@@ -33,6 +34,7 @@ A Neovim plugin that visually masks secrets in `.env`, `.json`, `.yaml`, `.toml`
 - **Telescope/Snacks Integration**: Mask values in preview buffers
 - **Zero file modification**: All masking is purely visual
 - **Extensible**: Register custom parsers for unsupported formats via a public API
+- **Programmable Checks**: Add local or async value checks with `register_check`
 
 ## Security Model
 
@@ -259,6 +261,60 @@ policy:
 The weak-secret check runs locally during masking and flags high-confidence weak values such as `password`, placeholders, repeated characters, short sensitive values, simple sequences, and low-entropy token-like strings. It uses key context, so benign values like `PORT=5432` are not treated like passwords.
 
 Badges render through the same central badge pipeline as HIBP and JWT expiry. The result text and metadata include the reason, key, and value length, but never the plaintext value. Use `checks.weak_secret.ignored_key_patterns` or `checks.weak_secret.ignored_value_patterns` to suppress noisy project-specific cases.
+
+## Custom Check API
+
+Register trusted Lua checks to inspect parsed variables and render redacted badges through the same pipeline used by weak-secret, HIBP, and JWT expiry checks.
+
+```lua
+require('camouflage').register_check({
+  name = 'local_policy',
+  priority = 60,
+  run = function(ctx)
+    if ctx.var.key:match('TOKEN') and ctx.var.value == 'changeme' then
+      return {
+        severity = 'warning',
+        text = '[policy]',
+        hl_group = 'DiagnosticWarn',
+        data = { reason = 'placeholder', key = ctx.var.key },
+      }
+    end
+  end,
+})
+```
+
+Checks receive plaintext values in `ctx.var.value`, so only register code you trust. Badge `text` and `data` should stay redacted; camouflage drops results that directly include the exact plaintext value.
+
+Async checks must opt in with `async = true` and call `done(result)`. Old async completions are ignored after buffer edits, unregister, buffer deletion, or a newer decoration run.
+
+```lua
+require('camouflage').register_check({
+  name = 'remote_policy',
+  async = true,
+  run = function(ctx, done)
+    vim.defer_fn(function()
+      done({ severity = 'info', text = '[checked]' })
+    end, 10)
+  end,
+})
+```
+
+Configure registered checks with data under `checks.<name>`:
+
+```lua
+require('camouflage').setup({
+  checks = {
+    local_policy = {
+      enabled = false,
+      label = 'team',
+    },
+  },
+})
+```
+
+Project config can set those data options but cannot register executable check code.
+
+With `debug = true`, custom check logs include check names, run counts, failures, and elapsed time without logging plaintext values.
 
 ## Supported File Formats
 

--- a/doc/camouflage.txt
+++ b/doc/camouflage.txt
@@ -18,16 +18,17 @@ CONTENTS                                                  *camouflage-contents*
   9. Supported Formats ....................... |camouflage-formats|
  10. Custom Patterns ......................... |camouflage-custom-patterns|
  11. Custom Parsers .......................... |camouflage-custom-parsers|
- 12. Styles .................................. |camouflage-styles|
- 13. Integrations ............................ |camouflage-integrations|
- 14. Project Config .......................... |camouflage-project-config|
- 15. Workspace Audit ......................... |camouflage-audit|
- 16. Rule-Based Policy ....................... |camouflage-policy|
- 17. Weak Secret Check ....................... |camouflage-weak-secret|
- 18. Have I Been Pwned ....................... |camouflage-pwned|
- 19. JWT Expiry Hints ........................ |camouflage-expiry|
- 20. Custom Queries .......................... |camouflage-custom-queries|
- 21. Troubleshooting ......................... |camouflage-troubleshooting|
+ 12. Custom Checks ........................... |camouflage-custom-checks|
+ 13. Styles .................................. |camouflage-styles|
+ 14. Integrations ............................ |camouflage-integrations|
+ 15. Project Config .......................... |camouflage-project-config|
+ 16. Workspace Audit ......................... |camouflage-audit|
+ 17. Rule-Based Policy ....................... |camouflage-policy|
+ 18. Weak Secret Check ....................... |camouflage-weak-secret|
+ 19. Have I Been Pwned ....................... |camouflage-pwned|
+ 20. JWT Expiry Hints ........................ |camouflage-expiry|
+ 21. Custom Queries .......................... |camouflage-custom-queries|
+ 22. Troubleshooting ......................... |camouflage-troubleshooting|
 
 ==============================================================================
 INTRODUCTION                                          *camouflage-introduction*
@@ -45,6 +46,7 @@ Features:
 - Workspace audit into quickfix/location list
 - Rule-based data-only policy for ignore/force-mask rules
 - Offline weak-secret quality badges
+- Public Lua check registration API
 - Buffer-local configuration overrides
 - Telescope and Snacks.nvim preview integration
 - Zero file modification
@@ -483,6 +485,25 @@ camouflage.list_parsers()
 camouflage.get_parser({name})
   Return the parser table registered under {name}, or nil.
 
+                                                   *camouflage.register_check()*
+camouflage.register_check({spec})
+  Register a trusted Lua check. See |camouflage-custom-checks| for details.
+
+  Parameters: ~
+    {spec}  Table with: name, run, async?, priority?, default_enabled?
+
+                                                 *camouflage.unregister_check()*
+camouflage.unregister_check({name})
+  Remove a registered check and clear its rendered badge results.
+
+                                                     *camouflage.list_checks()*
+camouflage.list_checks()
+  Return registered checks sorted by priority descending, then name.
+
+                                                      *camouflage.get_check()*
+camouflage.get_check({name})
+  Return the registered check entry under {name}, or nil.
+
                                                      *camouflage.pwned_check()*
 camouflage.pwned_check()
   Check if the value under cursor has been pwned. Requires Neovim 0.10+.
@@ -716,6 +737,112 @@ Runtime registrations that include `file_patterns` refresh automatic masking
 immediately after registration. Existing matching buffers are re-checked, and
 future BufEnter/TextChanged events use the new patterns without restarting
 Neovim.
+
+==============================================================================
+CUSTOM CHECKS                                      *camouflage-custom-checks*
+
+Custom checks let trusted Lua code inspect parsed variables during masking and
+render redacted badges through the shared check badge pipeline.
+
+Synchronous check example ~
+>lua
+  require('camouflage').register_check({
+    name = 'local_policy',
+    priority = 60,
+    run = function(ctx)
+      if ctx.var.key:match('TOKEN') and ctx.var.value == 'changeme' then
+        return {
+          severity = 'warning',
+          text = '[policy]',
+          hl_group = 'DiagnosticWarn',
+          data = { reason = 'placeholder', key = ctx.var.key },
+        }
+      end
+    end,
+  })
+<
+
+Async check example ~
+Async checks must opt in with `async = true` and call `done(result)`. Old
+completions are ignored if the buffer changed, the buffer was deleted, the
+check was unregistered, or a newer decoration run superseded the old run.
+>lua
+  require('camouflage').register_check({
+    name = 'remote_policy',
+    async = true,
+    run = function(ctx, done)
+      vim.defer_fn(function()
+        done({ severity = 'info', text = '[checked]' })
+      end, 10)
+    end,
+  })
+<
+
+Spec fields ~
+  name             string, required. Must be a stable check name.
+  run              function, required. Sync form is `run(ctx)`.
+                   Async form is `run(ctx, done)`.
+  async            boolean, optional. Defaults to false.
+  priority         integer, optional. Higher priority runs first.
+  default_enabled  boolean, optional. Defaults to true.
+
+Context fields ~
+  bufnr        Buffer number.
+  filename     Buffer filename used for parser selection.
+  parser_name  Parser name.
+  var          Parsed variable. `ctx.var.value` is plaintext.
+  config       Effective data table from `checks.<name>`.
+  run_id       Decoration run id.
+  check_name   Registered check name.
+
+Result fields ~
+  severity   Required: `info`, `warning`, or `error`.
+  text       Badge text. Keep this redacted.
+  hl_group   Virtual text highlight group.
+  sign_text  Optional sign column text.
+  sign_hl    Optional sign highlight group.
+  line_hl    Optional whole-line highlight group.
+  priority   Optional result priority metadata.
+  data       Optional data-only metadata. Keep this redacted.
+
+Privacy and trust ~
+Registered check functions are trusted Lua code. They receive plaintext values
+in `ctx.var.value`, just like parsers and local hooks. Do not register checks
+from untrusted repositories. Project config can only pass data under
+`checks.<name>`; it cannot register executable check code.
+
+camouflage drops a check result when `text` or `data` directly contains the
+exact plaintext value. This catches accidental leaks but is not a full data
+loss prevention system, so checks should intentionally return only redacted
+text and metadata.
+
+Configuration ~
+Registered checks read data options from `checks.<name>`. The `enabled` key
+can disable a registered check, and other keys are passed as `ctx.config`.
+>lua
+  require('camouflage').setup({
+    checks = {
+      local_policy = {
+        enabled = false,
+        label = 'team',
+      },
+    },
+  })
+<
+
+Observability ~
+With `debug = true`, custom check logs include check names, run counts,
+failures, and sync/async elapsed time without logging plaintext values.
+
+API ~
+>lua
+  local camouflage = require('camouflage')
+
+  camouflage.register_check(spec)
+  camouflage.unregister_check('local_policy')
+  camouflage.list_checks()
+  camouflage.get_check('local_policy')
+<
 
 ==============================================================================
 SUPPORTED FORMATS                                          *camouflage-formats*
@@ -1088,6 +1215,8 @@ Project config files support most configuration options:
 - integrations, yank, reveal, audit, policy, pwned, checks
 
 Note: The `project_config` key itself cannot be set in project config files.
+Project config may set data-only options for registered checks under
+`checks.<name>`, but it cannot register executable check functions.
 
 Watching for changes ~
                                             *camouflage-project-config-watch*

--- a/lua/camouflage/checks/init.lua
+++ b/lua/camouflage/checks/init.lua
@@ -9,6 +9,7 @@ local M = {}
 
 M.store = require('camouflage.checks.store')
 M.badges = require('camouflage.checks.badges')
+M.registry = require('camouflage.checks.registry')
 
 ---Set or clear a check's result on a single line and re-render.
 ---@param bufnr integer

--- a/lua/camouflage/checks/registry.lua
+++ b/lua/camouflage/checks/registry.lua
@@ -1,0 +1,535 @@
+---@mod camouflage.checks.registry Public check registry
+---@brief [[
+--- Runtime registry for trusted Lua checks. Registered checks inspect parsed
+--- variables during masking and publish redacted results through the shared
+--- checks badge store.
+---@brief ]]
+
+local M = {}
+
+local log = require('camouflage.log')
+
+---@class CamouflageCheckSpec
+---@field name string
+---@field run fun(ctx: CamouflageCheckContext, done?: fun(result: CheckResult|nil))
+---@field async? boolean
+---@field priority? integer
+---@field default_enabled? boolean
+
+---@class CamouflageCheckContext
+---@field bufnr integer
+---@field filename string
+---@field parser_name string
+---@field var ParsedVariable
+---@field config table
+---@field run_id integer
+---@field check_name string
+
+---@class CamouflageRegisteredCheck
+---@field name string
+---@field run fun(ctx: CamouflageCheckContext, done?: fun(result: CheckResult|nil))
+---@field async boolean
+---@field priority integer
+---@field default_enabled boolean
+
+---@type table<string, CamouflageRegisteredCheck>
+local registry = {}
+
+---@type table<integer, integer>
+local buffer_runs = {}
+
+local VALID_SEVERITY = { info = true, warning = true, error = true }
+local ALLOWED_RESULT_FIELDS = {
+  severity = true,
+  text = true,
+  hl_group = true,
+  sign_text = true,
+  sign_hl = true,
+  line_hl = true,
+  priority = true,
+  data = true,
+}
+
+---@param name string
+---@return boolean
+local function valid_name(name)
+  return type(name) == 'string' and name:match('^%a[%w_%-]*$') ~= nil and #name <= 64
+end
+
+---@param msg string
+local function reject(msg)
+  error('[camouflage] ' .. msg, 3)
+end
+
+---@param value any
+---@return boolean
+local function is_integer(value)
+  return type(value) == 'number' and value % 1 == 0
+end
+
+---@param bufnr integer
+---@return integer
+local function next_run_id(bufnr)
+  local run_id = (buffer_runs[bufnr] or 0) + 1
+  buffer_runs[bufnr] = run_id
+  return run_id
+end
+
+---@param value any
+---@param secret string
+---@param seen table<table, boolean>
+---@return boolean
+local function contains_secret(value, secret, seen)
+  if secret == '' then
+    return false
+  end
+
+  local value_type = type(value)
+  if value_type == 'string' then
+    return value:find(secret, 1, true) ~= nil
+  end
+  if value_type ~= 'table' then
+    return false
+  end
+  if seen[value] then
+    return false
+  end
+  seen[value] = true
+
+  for k, v in pairs(value) do
+    if contains_secret(k, secret, seen) or contains_secret(v, secret, seen) then
+      return true
+    end
+  end
+  return false
+end
+
+---@param value any
+---@param seen table<table, boolean>
+---@return boolean
+local function is_data_only(value, seen)
+  local value_type = type(value)
+  if
+    value == nil
+    or value_type == 'string'
+    or value_type == 'number'
+    or value_type == 'boolean'
+  then
+    return true
+  end
+  if value_type ~= 'table' then
+    return false
+  end
+  if seen[value] then
+    return true
+  end
+  seen[value] = true
+
+  for k, v in pairs(value) do
+    local key_type = type(k)
+    if key_type ~= 'string' and key_type ~= 'number' then
+      return false
+    end
+    if not is_data_only(v, seen) then
+      return false
+    end
+  end
+  return true
+end
+
+---@param check_name string
+---@param msg string
+local function debug_drop(check_name, msg)
+  log.debug('check %s result dropped: %s', check_name, msg)
+end
+
+---@param err any
+---@param ctx CamouflageCheckContext
+---@return string
+local function redacted_error(err, ctx)
+  local message = tostring(err)
+  local value = ctx.var and ctx.var.value
+  if type(value) == 'string' and value ~= '' then
+    message = message:gsub(vim.pesc(value), '[redacted]')
+  end
+  return message
+end
+
+---@param result any
+---@param ctx CamouflageCheckContext
+---@return CheckResult|nil
+local function normalize_result(result, ctx)
+  if result == nil then
+    return nil
+  end
+  if type(result) ~= 'table' then
+    debug_drop(ctx.check_name, 'result is not a table')
+    return nil
+  end
+  if not VALID_SEVERITY[result.severity] then
+    debug_drop(ctx.check_name, 'severity must be info, warning, or error')
+    return nil
+  end
+
+  local normalized = {}
+  for key, _ in pairs(ALLOWED_RESULT_FIELDS) do
+    normalized[key] = result[key]
+  end
+
+  if normalized.text ~= nil and type(normalized.text) ~= 'string' then
+    debug_drop(ctx.check_name, 'text must be a string')
+    return nil
+  end
+  if normalized.hl_group ~= nil and type(normalized.hl_group) ~= 'string' then
+    debug_drop(ctx.check_name, 'hl_group must be a string')
+    return nil
+  end
+  if normalized.sign_text ~= nil and type(normalized.sign_text) ~= 'string' then
+    debug_drop(ctx.check_name, 'sign_text must be a string')
+    return nil
+  end
+  if normalized.sign_hl ~= nil and type(normalized.sign_hl) ~= 'string' then
+    debug_drop(ctx.check_name, 'sign_hl must be a string')
+    return nil
+  end
+  if normalized.line_hl ~= nil and type(normalized.line_hl) ~= 'string' then
+    debug_drop(ctx.check_name, 'line_hl must be a string')
+    return nil
+  end
+  if normalized.priority ~= nil and not is_integer(normalized.priority) then
+    debug_drop(ctx.check_name, 'priority must be an integer')
+    return nil
+  end
+  if normalized.data ~= nil then
+    if type(normalized.data) ~= 'table' then
+      debug_drop(ctx.check_name, 'data must be a table')
+      return nil
+    end
+    if not is_data_only(normalized.data, {}) then
+      debug_drop(ctx.check_name, 'data must contain only primitive values and tables')
+      return nil
+    end
+  end
+
+  local value = ctx.var and ctx.var.value
+  if type(value) == 'string' and value ~= '' then
+    if normalized.text and normalized.text:find(value, 1, true) then
+      debug_drop(ctx.check_name, 'text contains the variable value')
+      return nil
+    end
+    if normalized.data and contains_secret(normalized.data, value, {}) then
+      debug_drop(ctx.check_name, 'data contains the variable value')
+      return nil
+    end
+  end
+
+  if normalized.data then
+    normalized.data = vim.deepcopy(normalized.data)
+  end
+  return normalized
+end
+
+---@param entry CamouflageRegisteredCheck
+---@return CamouflageRegisteredCheck
+local function public_entry(entry)
+  return {
+    name = entry.name,
+    run = entry.run,
+    async = entry.async,
+    priority = entry.priority,
+    default_enabled = entry.default_enabled,
+  }
+end
+
+---@param cfg table|nil
+---@param entry CamouflageRegisteredCheck
+---@return table
+---@return boolean
+local function check_config(cfg, entry)
+  local checks_cfg = (cfg and cfg.checks) or {}
+  local check_cfg = checks_cfg[entry.name] or {}
+  if type(check_cfg) ~= 'table' then
+    check_cfg = {}
+  end
+
+  local enabled = entry.default_enabled ~= false
+  if check_cfg.enabled ~= nil then
+    enabled = check_cfg.enabled ~= false
+  end
+  return check_cfg, enabled
+end
+
+---@param entries CamouflageRegisteredCheck[]
+---@return CamouflageRegisteredCheck[]
+local function sort_entries(entries)
+  table.sort(entries, function(a, b)
+    if a.priority ~= b.priority then
+      return a.priority > b.priority
+    end
+    return a.name < b.name
+  end)
+  return entries
+end
+
+---@return CamouflageRegisteredCheck[]
+local function sorted_entries()
+  local entries = {}
+  for _, entry in pairs(registry) do
+    table.insert(entries, entry)
+  end
+  return sort_entries(entries)
+end
+
+---@param bufnr integer
+local function clear_registered_results(bufnr)
+  local ok, checks = pcall(require, 'camouflage.checks')
+  if not ok then
+    return
+  end
+
+  for name, _ in pairs(registry) do
+    checks.clear_check(bufnr, name)
+  end
+end
+
+---@param bufnr integer
+---@param entry CamouflageRegisteredCheck
+---@param ctx CamouflageCheckContext
+---@return boolean
+local function still_current(bufnr, entry, ctx)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return false
+  end
+  if registry[entry.name] ~= entry then
+    return false
+  end
+  if buffer_runs[bufnr] ~= ctx.run_id then
+    return false
+  end
+  if ctx.changedtick ~= vim.api.nvim_buf_get_changedtick(bufnr) then
+    return false
+  end
+
+  local ok, state = pcall(require, 'camouflage.state')
+  if not ok then
+    return false
+  end
+  for _, var in ipairs(state.get_variables(bufnr) or {}) do
+    if
+      var.line_number == ctx.var.line_number
+      and var.start_index == ctx.var.start_index
+      and var.end_index == ctx.var.end_index
+      and var.key == ctx.var.key
+      and var.value == ctx.var.value
+    then
+      return true
+    end
+  end
+  return false
+end
+
+---@param bufnr integer
+---@param entry CamouflageRegisteredCheck
+---@param ctx CamouflageCheckContext
+---@param result any
+local function publish_result(bufnr, entry, ctx, result)
+  if not still_current(bufnr, entry, ctx) then
+    log.debug('check %s async result ignored for stale run %d', entry.name, ctx.run_id)
+    return
+  end
+
+  local normalized = normalize_result(result, ctx)
+  if normalized == nil then
+    return
+  end
+
+  require('camouflage.checks').set_result(bufnr, ctx.var.line_number, entry.name, normalized)
+end
+
+---@param entry CamouflageRegisteredCheck
+---@param ctx CamouflageCheckContext
+local function run_sync(entry, ctx)
+  local start = (vim.uv or vim.loop).hrtime()
+  local ok, result = pcall(entry.run, ctx)
+  local elapsed_ms = ((vim.uv or vim.loop).hrtime() - start) / 1000000
+  if not ok then
+    log.debug('check %s failed in %.2fms: %s', entry.name, elapsed_ms, redacted_error(result, ctx))
+    return
+  end
+  log.debug('check %s completed in %.2fms', entry.name, elapsed_ms)
+
+  local normalized = normalize_result(result, ctx)
+  if normalized == nil then
+    return
+  end
+  require('camouflage.checks').set_result(ctx.bufnr, ctx.var.line_number, entry.name, normalized)
+end
+
+---@param entry CamouflageRegisteredCheck
+---@param ctx CamouflageCheckContext
+local function run_async(entry, ctx)
+  local start = (vim.uv or vim.loop).hrtime()
+  local done_called = false
+  local done = vim.schedule_wrap(function(result)
+    local elapsed_ms = ((vim.uv or vim.loop).hrtime() - start) / 1000000
+    if done_called then
+      log.debug('check %s ignored duplicate async completion in %.2fms', entry.name, elapsed_ms)
+      return
+    end
+    done_called = true
+    log.debug('check %s async completed in %.2fms', entry.name, elapsed_ms)
+    publish_result(ctx.bufnr, entry, ctx, result)
+  end)
+
+  local ok, err = pcall(entry.run, ctx, done)
+  if not ok then
+    log.debug('check %s failed to start async run: %s', entry.name, redacted_error(err, ctx))
+  end
+end
+
+---Register a public check.
+---@param spec CamouflageCheckSpec
+---@return CamouflageRegisteredCheck
+function M.register(spec)
+  if type(spec) ~= 'table' then
+    reject('register_check requires a spec table')
+  end
+  if not valid_name(spec.name) then
+    reject('register_check requires a valid name')
+  end
+  if registry[spec.name] then
+    reject(string.format('check "%s" is already registered', spec.name))
+  end
+  if type(spec.run) ~= 'function' then
+    reject('register_check requires a run function')
+  end
+  if spec.async ~= nil and type(spec.async) ~= 'boolean' then
+    reject('register_check async must be a boolean')
+  end
+  if spec.default_enabled ~= nil and type(spec.default_enabled) ~= 'boolean' then
+    reject('register_check default_enabled must be a boolean')
+  end
+  if spec.priority ~= nil and not is_integer(spec.priority) then
+    reject('register_check priority must be an integer')
+  end
+
+  local entry = {
+    name = spec.name,
+    run = spec.run,
+    async = spec.async == true,
+    priority = spec.priority or 50,
+    default_enabled = spec.default_enabled ~= false,
+  }
+  registry[entry.name] = entry
+  log.debug('registered check %s async=%s priority=%d', entry.name, entry.async, entry.priority)
+  return public_entry(entry)
+end
+
+---Unregister a check and clear its rendered results from loaded buffers.
+---@param name string
+---@return boolean removed
+function M.unregister(name)
+  if type(name) ~= 'string' or not registry[name] then
+    return false
+  end
+  registry[name] = nil
+
+  local ok, checks = pcall(require, 'camouflage.checks')
+  if ok then
+    for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+      checks.clear_check(bufnr, name)
+    end
+  end
+  log.debug('unregistered check %s', name)
+  return true
+end
+
+---List registered checks sorted by priority descending, then name.
+---@return CamouflageRegisteredCheck[]
+function M.list()
+  local entries = {}
+  for _, entry in ipairs(sorted_entries()) do
+    table.insert(entries, public_entry(entry))
+  end
+  return entries
+end
+
+---Get a registered check by name.
+---@param name string
+---@return CamouflageRegisteredCheck|nil
+function M.get(name)
+  local entry = registry[name]
+  return entry and public_entry(entry) or nil
+end
+
+---Start a new decoration pass for registered checks.
+---@param bufnr integer
+---@return integer run_id
+function M.begin_decorate(bufnr)
+  local run_id = next_run_id(bufnr)
+  clear_registered_results(bufnr)
+  return run_id
+end
+
+---Run enabled registered checks for parsed variables.
+---@param opts { bufnr: integer, filename: string, parser_name: string, variables: ParsedVariable[], config: table, run_id?: integer }
+function M.run(opts)
+  if not opts or type(opts) ~= 'table' then
+    return
+  end
+  local bufnr = opts.bufnr
+  if type(bufnr) ~= 'number' or not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
+  local entries = sorted_entries()
+  if #entries == 0 then
+    return
+  end
+
+  local run_id = opts.run_id or next_run_id(bufnr)
+  buffer_runs[bufnr] = run_id
+  local variables = opts.variables or {}
+  local changedtick = vim.api.nvim_buf_get_changedtick(bufnr)
+  log.debug(
+    'running %d registered checks for %d variables in buffer %d run %d',
+    #entries,
+    #variables,
+    bufnr,
+    run_id
+  )
+
+  for _, var in ipairs(variables) do
+    for _, entry in ipairs(entries) do
+      local check_cfg, enabled = check_config(opts.config, entry)
+      if enabled then
+        local ctx = {
+          bufnr = bufnr,
+          filename = opts.filename,
+          parser_name = opts.parser_name,
+          var = var,
+          config = check_cfg,
+          run_id = run_id,
+          check_name = entry.name,
+          changedtick = changedtick,
+        }
+        if entry.async then
+          run_async(entry, ctx)
+        else
+          run_sync(entry, ctx)
+        end
+      end
+    end
+  end
+end
+
+---Internal: reset registry state for tests.
+function M._reset()
+  registry = {}
+  buffer_runs = {}
+end
+
+---Internal: expose result validation for focused tests.
+M._normalize_result = normalize_result
+
+return M

--- a/lua/camouflage/config.lua
+++ b/lua/camouflage/config.lua
@@ -156,6 +156,8 @@ local M = {}
 ---@field pwned? CamouflagePwnedConfig
 ---@field expiry? CamouflageExpiryConfig
 ---@field weak_secret? CamouflageWeakSecretConfig
+--- Registered public checks can also read data-only options from
+--- `checks.<name>`, including `enabled`.
 
 ---@class CamouflageProjectConfigLoaderConfig
 ---@field enabled? boolean Enable repo config loading (default: true)

--- a/lua/camouflage/core.lua
+++ b/lua/camouflage/core.lua
@@ -10,6 +10,7 @@ local hooks = require('camouflage.hooks')
 local log = require('camouflage.log')
 local position = require('camouflage.position')
 local policy = require('camouflage.policy')
+local check_registry = require('camouflage.checks.registry')
 
 -- Position math lives in the leaf module camouflage.position so yank/pwned can
 -- reuse it without depending on the whole decoration engine. These permanent
@@ -91,6 +92,7 @@ function M.apply_decorations(bufnr, override_filename)
   -- Always clear first so a no-mask outcome (disabled, too large, no parser, no
   -- variables) never leaves stale extmarks drifting over the buffer.
   M.clear_decorations(bufnr)
+  local check_run_id = check_registry.begin_decorate(bufnr)
 
   -- Buffer-local config (vim.b.camouflage_*) overrides the global config; with
   -- no overrides this returns the shared config table at no extra cost.
@@ -172,6 +174,15 @@ function M.apply_decorations(bufnr, override_filename)
     policy_stats = policy_result.stats,
   })
   state.clear_dirty(bufnr)
+
+  check_registry.run({
+    bufnr = bufnr,
+    filename = filename,
+    parser_name = parser_name,
+    variables = filtered_variables,
+    config = cfg,
+    run_id = check_run_id,
+  })
 
   -- Pre-compute line offsets for O(1) index lookups
   local line_offsets = M.compute_line_offsets(lines)

--- a/lua/camouflage/init.lua
+++ b/lua/camouflage/init.lua
@@ -631,6 +631,42 @@ function M.get_parser(name)
   return require('camouflage.parsers').get(name)
 end
 
+-- Check API
+---Register a trusted Lua check that runs on parsed variables during masking.
+---
+---Spec fields:
+---  name (string, required)
+---  run (function, required)                  -- sync: run(ctx), async: run(ctx, done)
+---  async (boolean, optional, default false)
+---  priority (integer, optional, default 50)  -- higher runs first
+---  default_enabled (boolean, optional, default true)
+---
+---@param spec CamouflageCheckSpec
+---@return CamouflageRegisteredCheck
+function M.register_check(spec)
+  return require('camouflage.checks.registry').register(spec)
+end
+
+---Unregister a check by name and clear its rendered results.
+---@param name string
+---@return boolean removed
+function M.unregister_check(name)
+  return require('camouflage.checks.registry').unregister(name)
+end
+
+---List registered checks sorted by priority descending, then name.
+---@return CamouflageRegisteredCheck[]
+function M.list_checks()
+  return require('camouflage.checks.registry').list()
+end
+
+---Get a registered check by name.
+---@param name string
+---@return CamouflageRegisteredCheck|nil
+function M.get_check(name)
+  return require('camouflage.checks.registry').get(name)
+end
+
 -- Repo project config API
 M.project_config_status = function()
   return require('camouflage.project_config').status()

--- a/tests/camouflage/checks/registry_spec.lua
+++ b/tests/camouflage/checks/registry_spec.lua
@@ -1,0 +1,386 @@
+local registry = require('camouflage.checks.registry')
+local store = require('camouflage.checks.store')
+local state = require('camouflage.state')
+local config = require('camouflage.config')
+
+local function fresh_buffer(lines)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_name(bufnr, vim.fn.tempname() .. '.env')
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines or { 'API_KEY=secret-value' })
+  return bufnr
+end
+
+local function parsed_var(key, value, line)
+  return {
+    key = key,
+    value = value,
+    line_number = line or 0,
+    start_index = 8,
+    end_index = 8 + #value,
+    is_nested = false,
+    is_commented = false,
+  }
+end
+
+local function run_checks(bufnr, variables, cfg)
+  state.update_buffer(bufnr, {
+    enabled = true,
+    variables = variables,
+    parser = 'env',
+  })
+  local run_id = registry.begin_decorate(bufnr)
+  registry.run({
+    bufnr = bufnr,
+    filename = vim.api.nvim_buf_get_name(bufnr),
+    parser_name = 'env',
+    variables = variables,
+    config = cfg or config.get(),
+    run_id = run_id,
+  })
+  return run_id
+end
+
+describe('camouflage.checks.registry', function()
+  before_each(function()
+    registry._reset()
+    store._reset()
+    state.clear()
+    config.setup()
+  end)
+
+  describe('registration', function()
+    it('registers, lists, gets, and unregisters checks', function()
+      registry.register({
+        name = 'local_policy',
+        priority = 80,
+        run = function() end,
+      })
+      registry.register({
+        name = 'org_policy',
+        priority = 90,
+        default_enabled = false,
+        run = function() end,
+      })
+
+      local listed = registry.list()
+      assert.equals('org_policy', listed[1].name)
+      assert.equals('local_policy', listed[2].name)
+      assert.is_true(listed[2].default_enabled)
+      assert.is_false(listed[1].default_enabled)
+
+      local fetched = registry.get('local_policy')
+      assert.is_table(fetched)
+      assert.equals('local_policy', fetched.name)
+
+      assert.is_true(registry.unregister('local_policy'))
+      assert.is_nil(registry.get('local_policy'))
+      assert.is_false(registry.unregister('local_policy'))
+    end)
+
+    it('rejects invalid specs and duplicate names', function()
+      assert.has.errors(function()
+        registry.register({})
+      end)
+      assert.has.errors(function()
+        registry.register({ name = 'bad/name', run = function() end })
+      end)
+      assert.has.errors(function()
+        registry.register({ name = 'no_run' })
+      end)
+
+      registry.register({ name = 'duplicate', run = function() end })
+      assert.has.errors(function()
+        registry.register({ name = 'duplicate', run = function() end })
+      end)
+    end)
+
+    it('clears rendered results when a check is unregistered', function()
+      local bufnr = fresh_buffer()
+      registry.register({
+        name = 'cleanup_check',
+        run = function()
+          return { severity = 'info', text = '[cleanup]' }
+        end,
+      })
+
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+      assert.is_table(store.get(bufnr, 0, 'cleanup_check'))
+
+      registry.unregister('cleanup_check')
+      assert.is_nil(store.get(bufnr, 0, 'cleanup_check'))
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
+
+  describe('synchronous checks', function()
+    it('runs enabled checks with useful context and stores redacted results', function()
+      local bufnr = fresh_buffer()
+      local seen_ctx
+      config.setup({
+        checks = {
+          local_policy = {
+            enabled = true,
+            label = 'org',
+          },
+        },
+      })
+      registry.register({
+        name = 'local_policy',
+        run = function(ctx)
+          seen_ctx = ctx
+          return {
+            severity = 'warning',
+            text = '[' .. ctx.config.label .. ']',
+            hl_group = 'DiagnosticWarn',
+            data = { key = ctx.var.key, value_length = #ctx.var.value },
+          }
+        end,
+      })
+
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+
+      assert.equals(bufnr, seen_ctx.bufnr)
+      assert.equals('env', seen_ctx.parser_name)
+      assert.equals('API_KEY', seen_ctx.var.key)
+      assert.equals('org', seen_ctx.config.label)
+      assert.is_number(seen_ctx.run_id)
+      assert.equals('local_policy', seen_ctx.check_name)
+
+      local result = store.get(bufnr, 0, 'local_policy')
+      assert.is_table(result)
+      assert.equals('[org]', result.text)
+      assert.equals('API_KEY', result.data.key)
+      assert.equals(#'secret-value', result.data.value_length)
+      assert.is_nil(result.text:find('secret-value', 1, true))
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('skips checks disabled through checks.<name>.enabled', function()
+      local bufnr = fresh_buffer()
+      config.setup({ checks = { local_policy = { enabled = false } } })
+      registry.register({
+        name = 'local_policy',
+        run = function()
+          return { severity = 'warning', text = '[local]' }
+        end,
+      })
+
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+
+      assert.is_nil(store.get(bufnr, 0, 'local_policy'))
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('uses default_enabled unless config overrides it', function()
+      local bufnr = fresh_buffer()
+      registry.register({
+        name = 'opt_in_check',
+        default_enabled = false,
+        run = function()
+          return { severity = 'info', text = '[opt-in]' }
+        end,
+      })
+
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+      assert.is_nil(store.get(bufnr, 0, 'opt_in_check'))
+
+      config.setup({ checks = { opt_in_check = { enabled = true } } })
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+      assert.is_table(store.get(bufnr, 0, 'opt_in_check'))
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('isolates crashing checks so later checks and masking continue', function()
+      local bufnr = fresh_buffer()
+      registry.register({
+        name = 'crashing_check',
+        priority = 100,
+        run = function()
+          error('boom')
+        end,
+      })
+      registry.register({
+        name = 'healthy_check',
+        priority = 10,
+        run = function()
+          return { severity = 'info', text = '[healthy]' }
+        end,
+      })
+
+      assert.has_no.errors(function()
+        run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+      end)
+      assert.is_table(store.get(bufnr, 0, 'healthy_check'))
+      assert.is_nil(store.get(bufnr, 0, 'crashing_check'))
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('redacts plaintext values from debug failure logs', function()
+      local bufnr = fresh_buffer()
+      local notifications = {}
+      local original_notify = vim.notify
+      vim.notify = function(msg, level)
+        table.insert(notifications, { msg = msg, level = level })
+      end
+      config.setup({ debug = true })
+      registry.register({
+        name = 'crashing_check',
+        run = function(ctx)
+          error('failed for ' .. ctx.var.value)
+        end,
+      })
+
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+
+      vim.notify = original_notify
+      local combined = vim.inspect(notifications)
+      assert.is_nil(combined:find('secret-value', 1, true))
+      assert.is_not_nil(combined:find('%[redacted%]'))
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('drops invalid results and exact plaintext leaks', function()
+      local bufnr = fresh_buffer()
+      registry.register({
+        name = 'invalid_check',
+        run = function()
+          return { severity = 'critical', text = '[bad]' }
+        end,
+      })
+      registry.register({
+        name = 'text_leak',
+        run = function(ctx)
+          return { severity = 'error', text = 'leaked ' .. ctx.var.value }
+        end,
+      })
+      registry.register({
+        name = 'data_leak',
+        run = function(ctx)
+          return { severity = 'error', text = '[leak]', data = { raw = ctx.var.value } }
+        end,
+      })
+
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+
+      assert.is_nil(store.get(bufnr, 0, 'invalid_check'))
+      assert.is_nil(store.get(bufnr, 0, 'text_leak'))
+      assert.is_nil(store.get(bufnr, 0, 'data_leak'))
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
+
+  describe('asynchronous checks', function()
+    it('publishes async results through the completion callback', function()
+      local bufnr = fresh_buffer()
+      local complete
+      registry.register({
+        name = 'remote_policy',
+        async = true,
+        run = function(_, done)
+          complete = done
+        end,
+      })
+
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+      complete({ severity = 'warning', text = '[remote]' })
+
+      vim.wait(100, function()
+        return store.get(bufnr, 0, 'remote_policy') ~= nil
+      end)
+      assert.equals('[remote]', store.get(bufnr, 0, 'remote_policy').text)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('ignores old async results after a newer run supersedes them', function()
+      local bufnr = fresh_buffer()
+      local completions = {}
+      registry.register({
+        name = 'remote_policy',
+        async = true,
+        run = function(_, done)
+          table.insert(completions, done)
+        end,
+      })
+
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+      run_checks(bufnr, { parsed_var('API_KEY', 'new-secret') })
+
+      completions[1]({ severity = 'warning', text = '[old]' })
+      completions[2]({ severity = 'warning', text = '[new]' })
+
+      vim.wait(100, function()
+        local result = store.get(bufnr, 0, 'remote_policy')
+        return result and result.text == '[new]'
+      end)
+      assert.equals('[new]', store.get(bufnr, 0, 'remote_policy').text)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('ignores async results after the buffer changes before completion', function()
+      local bufnr = fresh_buffer()
+      local complete
+      registry.register({
+        name = 'remote_policy',
+        async = true,
+        run = function(_, done)
+          complete = done
+        end,
+      })
+
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'API_KEY=changed' })
+      complete({ severity = 'warning', text = '[stale]' })
+
+      vim.wait(50, function()
+        return store.get(bufnr, 0, 'remote_policy') ~= nil
+      end)
+      assert.is_nil(store.get(bufnr, 0, 'remote_policy'))
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('ignores async results after unregister or buffer deletion', function()
+      local bufnr = fresh_buffer()
+      local complete
+      registry.register({
+        name = 'remote_policy',
+        async = true,
+        run = function(_, done)
+          complete = done
+        end,
+      })
+
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+      registry.unregister('remote_policy')
+      complete({ severity = 'warning', text = '[gone]' })
+      vim.wait(50, function()
+        return store.get(bufnr, 0, 'remote_policy') ~= nil
+      end)
+      assert.is_nil(store.get(bufnr, 0, 'remote_policy'))
+
+      registry.register({
+        name = 'remote_policy',
+        async = true,
+        run = function(_, done)
+          complete = done
+        end,
+      })
+      run_checks(bufnr, { parsed_var('API_KEY', 'secret-value') })
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+      assert.has_no.errors(function()
+        complete({ severity = 'warning', text = '[deleted]' })
+        vim.wait(20, function()
+          return false
+        end)
+      end)
+    end)
+  end)
+end)

--- a/tests/camouflage/config_spec.lua
+++ b/tests/camouflage/config_spec.lua
@@ -161,6 +161,21 @@ describe('camouflage.config', function()
       assert.equals('[weak: %s]', weak_secret.virtual_text_format)
       assert.is_table(weak_secret.sensitive_key_patterns)
     end)
+
+    it('returns custom registered-check configuration by name', function()
+      config.setup({
+        checks = {
+          local_policy = {
+            enabled = false,
+            label = 'team',
+          },
+        },
+      })
+
+      local local_policy = config.get_check('local_policy')
+      assert.is_false(local_policy.enabled)
+      assert.equals('team', local_policy.label)
+    end)
   end)
 
   describe('checks.pwned canonical namespace', function()

--- a/tests/camouflage/core_spec.lua
+++ b/tests/camouflage/core_spec.lua
@@ -2,6 +2,8 @@ local core = require('camouflage.core')
 local state = require('camouflage.state')
 local config = require('camouflage.config')
 local hooks = require('camouflage.hooks')
+local check_registry = require('camouflage.checks.registry')
+local checks_store = require('camouflage.checks.store')
 
 local function setup_buffer(lines, filename)
   local bufnr = vim.api.nvim_create_buf(false, true)
@@ -17,6 +19,8 @@ describe('camouflage.core', function()
     hooks.clear()
     hooks.setup(nil)
     require('camouflage.parsers').setup()
+    check_registry._reset()
+    checks_store._reset()
     vim.wait(20, function()
       return false
     end)
@@ -313,6 +317,60 @@ describe('camouflage.core', function()
       assert.same({}, state.get_variables(bufnr))
       assert.equals(1, stats.total)
       assert.equals(1, stats.ignored)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('should run registered checks for variables that survive policy and hooks', function()
+      local checks = require('camouflage.checks')
+      local badges = require('camouflage.checks.badges')
+      config.setup({
+        policy = {
+          rules = {
+            { id = 'ignore-debug', action = 'ignore', key = { '^DEBUG$' } },
+          },
+        },
+        checks = {
+          custom_policy = {
+            label = 'custom',
+          },
+        },
+      })
+      check_registry.register({
+        name = 'custom_policy',
+        run = function(ctx)
+          assert.equals('API_KEY', ctx.var.key)
+          assert.equals('custom', ctx.config.label)
+          return {
+            severity = 'warning',
+            text = '[custom]',
+            hl_group = 'DiagnosticWarn',
+            data = { key = ctx.var.key },
+          }
+        end,
+      })
+      local bufnr = setup_buffer({ 'DEBUG=true', 'API_KEY=secret' })
+      checks.set_result(bufnr, 1, 'pwned', {
+        severity = 'error',
+        text = '[PWNED]',
+        hl_group = 'DiagnosticError',
+      })
+
+      core.apply_decorations(bufnr)
+
+      assert.is_nil(checks_store.get(bufnr, 0, 'custom_policy'))
+      assert.is_table(checks_store.get(bufnr, 1, 'custom_policy'))
+      assert.is_table(checks_store.get(bufnr, 1, 'pwned'))
+
+      local marks = vim.api.nvim_buf_get_extmarks(
+        bufnr,
+        badges.get_namespace(),
+        { 1, 0 },
+        { 1, -1 },
+        { details = true }
+      )
+      assert.equals('[PWNED]', marks[1][4].virt_text[1][1])
+      assert.equals('[custom]', marks[1][4].virt_text[3][1])
 
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)

--- a/tests/camouflage/init_spec.lua
+++ b/tests/camouflage/init_spec.lua
@@ -127,4 +127,31 @@ describe('camouflage.init', function()
       end)
     end)
   end)
+
+  describe('check API', function()
+    before_each(function()
+      clear_camouflage_modules()
+      camouflage = require('camouflage')
+    end)
+
+    it('should expose register, unregister, list, and get functions', function()
+      assert.is_function(camouflage.register_check)
+      assert.is_function(camouflage.unregister_check)
+      assert.is_function(camouflage.list_checks)
+      assert.is_function(camouflage.get_check)
+    end)
+
+    it('should register checks through the public API', function()
+      local entry = camouflage.register_check({
+        name = 'api_check',
+        run = function() end,
+      })
+
+      assert.equals('api_check', entry.name)
+      assert.equals('api_check', camouflage.get_check('api_check').name)
+      assert.equals(1, #camouflage.list_checks())
+      assert.is_true(camouflage.unregister_check('api_check'))
+      assert.is_nil(camouflage.get_check('api_check'))
+    end)
+  end)
 end)

--- a/tests/camouflage/project_config_spec.lua
+++ b/tests/camouflage/project_config_spec.lua
@@ -285,4 +285,29 @@ describe('camouflage.project_config', function()
     assert.same({ '^TEST_' }, weak_secret.ignored_key_patterns)
     assert.same({ '^example$' }, weak_secret.ignored_value_patterns)
   end)
+
+  it('should load custom check configuration without registering executable checks', function()
+    local dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    vim.fn.writefile({
+      'version: 1',
+      'checks:',
+      '  local_policy:',
+      '    enabled: false',
+      '    label: project',
+      '    run: "return function() end"',
+    }, dir .. '/.camouflage.yaml')
+    vim.cmd('cd ' .. vim.fn.fnameescape(dir))
+
+    local registry = require('camouflage.checks.registry')
+    registry._reset()
+
+    config.setup()
+    local local_policy = config.get().checks.local_policy
+
+    assert.is_false(local_policy.enabled)
+    assert.equals('project', local_policy.label)
+    assert.equals('return function() end', local_policy.run)
+    assert.equals(0, #registry.list())
+  end)
 end)


### PR DESCRIPTION
## Description

This PR adds a public Lua check API so plugin users and third-party integrations can register trusted value-level checks without patching internal modules or manually writing badge results.

What changed:

- Adds `camouflage.checks.registry` with check registration, lookup, listing, unregistration, spec validation, result validation, and cleanup.
- Exposes `register_check`, `unregister_check`, `list_checks`, and `get_check` on `require('camouflage')`.
- Runs registered checks during the decoration pipeline after policy and hook filtering, writing results through the existing shared badge renderer.
- Supports synchronous checks and explicit `async = true` checks with stale-result protection for newer runs, buffer edits, unregister, and deleted buffers.
- Allows user and project config to pass data-only options under `checks.<name>`, including `enabled`, without allowing project config to register executable code.
- Documents the trusted-code plaintext boundary, result redaction expectations, sync/async examples, config controls, and debug observability.

Security and compatibility notes:

- Existing built-in pwned, expiry, weak-secret, parser, hook, and badge behavior remains unchanged.
- Check errors are isolated so one third-party check cannot break masking or other checks.
- Direct plaintext leaks in badge text/data are dropped, and debug failure logs redact the exact parsed value.

Validation performed:

- `make format`
- `make format-check`
- `make lint`
- `make test`
- `git diff --check`

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

## Screenshots (if applicable)

N/A
