### PR TITLE
fix(init): mask loaded buffers during setup

### DIFF
--- a/lua/camouflage/init.lua
+++ b/lua/camouflage/init.lua
@@ -390,7 +390,6 @@ function M.setup(opts)
   end
 
   require('camouflage.config').setup(opts)
-  reconfigure_runtime()
 
   -- Setup hooks with config
   local hooks_config = opts and opts.hooks or nil
@@ -417,6 +416,8 @@ function M.setup(opts)
   if weak_secret_ok then
     weak_secret.setup()
   end
+
+  reconfigure_runtime()
 
   initialized = true
 

--- a/tests/camouflage/init_spec.lua
+++ b/tests/camouflage/init_spec.lua
@@ -16,6 +16,23 @@ describe('camouflage.init', function()
   end)
 
   describe('setup', function()
+    local function no_network_opts()
+      return {
+        pwned = { enabled = false },
+        checks = {
+          pwned = { enabled = false },
+        },
+      }
+    end
+
+    local function create_named_buffer(lines, filename)
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_name(bufnr, filename)
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+      vim.api.nvim_set_current_buf(bufnr)
+      return bufnr
+    end
+
     it('should initialize without options', function()
       assert.has_no.errors(function()
         camouflage.setup()
@@ -47,6 +64,82 @@ describe('camouflage.init', function()
 
       vim.notify = original_notify
       assert.is_true(notified)
+    end)
+
+    it('should mask supported buffers loaded before setup', function()
+      local bufnr = create_named_buffer({ 'API_KEY=secret' }, vim.fn.tempname() .. '.env')
+
+      camouflage.setup(no_network_opts())
+
+      local state = require('camouflage.state')
+      local variables = state.get_variables(bufnr)
+      local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, state.namespace, 0, -1, {})
+
+      assert.is_true(state.is_buffer_masked(bufnr))
+      assert.equals(1, #variables)
+      assert.equals('API_KEY', variables[1].key)
+      assert.equals('secret', variables[1].value)
+      assert.equals(1, #extmarks)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('should run check hooks during the initial loaded-buffer pass', function()
+      local bufnr = create_named_buffer({ 'PASSWORD=password' }, vim.fn.tempname() .. '.env')
+
+      camouflage.setup(no_network_opts())
+
+      local result = require('camouflage.checks.store').get(bufnr, 0, 'weak_secret')
+
+      assert.is_table(result)
+      assert.equals('[weak: default]', result.text)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('should not decorate unsupported or project config buffers during setup', function()
+      local unsupported =
+        create_named_buffer({ 'API_KEY=secret' }, vim.fn.tempname() .. '.unsupported')
+      local project_dir = vim.fn.tempname()
+      vim.fn.mkdir(project_dir, 'p')
+      local project_config =
+        create_named_buffer({ 'API_KEY: secret' }, project_dir .. '/.camouflage.yaml')
+
+      camouflage.setup(no_network_opts())
+
+      local state = require('camouflage.state')
+      for _, bufnr in ipairs({ unsupported, project_config }) do
+        local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, state.namespace, 0, -1, {})
+        assert.is_false(state.is_buffer_masked(bufnr))
+        assert.equals(0, #state.get_variables(bufnr))
+        assert.equals(0, #extmarks)
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+      vim.fn.delete(project_dir, 'rf')
+    end)
+
+    it('should not create runtime autocmds if parser setup fails', function()
+      local state = require('camouflage.state')
+      local original_preload = package.preload['camouflage.parsers.env']
+      local original_loaded = package.loaded['camouflage.parsers.env']
+      package.loaded['camouflage.parsers.env'] = nil
+      package.preload['camouflage.parsers.env'] = function()
+        error('parser setup boom')
+      end
+
+      local ok, err = pcall(function()
+        camouflage.setup(no_network_opts())
+      end)
+
+      package.preload['camouflage.parsers.env'] = original_preload
+      package.loaded['camouflage.parsers.env'] = original_loaded
+
+      local found = tostring(err):find('parser setup boom', 1, true)
+      local autocmds = vim.api.nvim_get_autocmds({ group = state.augroup })
+
+      assert.is_false(ok)
+      assert.is_not_nil(found)
+      assert.equals(0, #autocmds)
     end)
   end)
 


### PR DESCRIPTION
## Description

This fixes startup masking for buffers that are already loaded before `require('camouflage').setup()` runs.

Previously, setup reconfigured runtime and called `autocmds.apply_to_loaded_buffers()` before built-in parsers and check hooks were registered. Since loaded-buffer decoration is gated by `parsers.is_supported(filename)`, preloaded supported files could be skipped during the initial pass and remain unmasked until a later refresh, edit, or buffer event.

This change moves runtime reconfiguration after hook setup, parser registration, command setup, and optional check setup so the first loaded-buffer pass has the complete registry and check listeners available.

Regression coverage was added for:

- preloaded `.env` buffers getting parsed variables and mask extmarks during setup
- weak-secret hooks running during the initial loaded-buffer pass
- unsupported files and `.camouflage.yaml` staying undecorated
- parser setup failures not leaving runtime autocmds installed

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Verification

- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/init_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/commands_spec.lua"`
- [x] `make test`
- [x] `make lint`
- [x] `make format`
- [x] `make format-check`

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

## Screenshots (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior so supported open files are masked more reliably during setup.
  * Ensured unsupported files and project config files are left untouched during initialization.
  * Prevented runtime listeners from being registered if setup fails, avoiding partial initialization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->