### PR TITLE
fix(core): reset mask state on no-mask paths

### DIFF
--- a/lua/camouflage/core.lua
+++ b/lua/camouflage/core.lua
@@ -63,7 +63,10 @@ end
 ---window wrap.
 ---@param bufnr number
 local function reset_mask_state(bufnr)
-  state.clear_variables(bufnr)
+  state.update_buffer(bufnr, {
+    enabled = false,
+    variables = {},
+  })
   state.clear_policy_stats(bufnr)
   restore_wrap(bufnr)
 end

--- a/tests/camouflage/core_spec.lua
+++ b/tests/camouflage/core_spec.lua
@@ -13,6 +13,26 @@ local function setup_buffer(lines, filename)
   return bufnr
 end
 
+local function assert_unmasked_state(bufnr)
+  local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, state.namespace, 0, -1, {})
+  assert.equals(0, #extmarks)
+  assert.equals(0, #state.get_variables(bufnr))
+  assert.is_false(state.is_buffer_masked(bufnr))
+  assert.is_nil(state.get_policy_stats(bufnr))
+end
+
+local function setup_masked_buffer(lines, filename)
+  local bufnr = setup_buffer(lines, filename)
+  core.apply_decorations(bufnr)
+
+  local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, state.namespace, 0, -1, {})
+  assert.is_true(state.is_buffer_masked(bufnr))
+  assert.is_true(#state.get_variables(bufnr) > 0)
+  assert.is_true(#extmarks > 0)
+
+  return bufnr
+end
+
 describe('camouflage.core', function()
   before_each(function()
     config.setup()
@@ -160,9 +180,8 @@ describe('camouflage.core', function()
   end)
 
   describe('apply_decorations', function()
-    it('should skip when disabled', function()
-      local bufnr = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_set_current_buf(bufnr)
+    it('should clear stale mask state when disabled', function()
+      local bufnr = setup_masked_buffer({ 'API_KEY=secret' })
 
       config.set('enabled', false)
 
@@ -170,12 +189,13 @@ describe('camouflage.core', function()
         core.apply_decorations(bufnr)
       end)
 
+      assert_unmasked_state(bufnr)
+
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
-    it('should skip files over max_lines', function()
-      local bufnr = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_set_current_buf(bufnr)
+    it('should clear stale mask state when files exceed max_lines', function()
+      local bufnr = setup_masked_buffer({ 'API_KEY=secret' })
 
       -- Create a buffer with many lines
       local lines = {}
@@ -191,9 +211,7 @@ describe('camouflage.core', function()
         core.apply_decorations(bufnr)
       end)
 
-      -- Should not have created any extmarks
-      local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, state.namespace, 0, -1, {})
-      assert.equals(0, #extmarks)
+      assert_unmasked_state(bufnr)
 
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
@@ -211,14 +229,55 @@ describe('camouflage.core', function()
     end)
 
     it('should skip unsupported file types', function()
-      local bufnr = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_buf_set_name(bufnr, 'test.unsupported')
-      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'some content' })
-      vim.api.nvim_set_current_buf(bufnr)
+      local bufnr = setup_masked_buffer({ 'API_KEY=secret' })
 
       assert.has_no.errors(function()
-        core.apply_decorations(bufnr)
+        core.apply_decorations(bufnr, 'test.unsupported')
       end)
+
+      assert_unmasked_state(bufnr)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('should clear stale mask state when parser returns no variables', function()
+      local bufnr = setup_masked_buffer({ 'API_KEY=secret' })
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'plain text without assignments' })
+
+      core.apply_decorations(bufnr)
+
+      assert_unmasked_state(bufnr)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('should clear stale mask state when buffer-local config disables masking', function()
+      local bufnr = setup_masked_buffer({ 'API_KEY=secret' })
+      vim.b[bufnr].camouflage_enabled = false
+
+      core.apply_decorations(bufnr)
+
+      assert_unmasked_state(bufnr)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('should clear stale variables so yank, reveal, and checks cannot use them', function()
+      local bufnr = setup_masked_buffer({ 'PASSWORD=password' })
+      vim.api.nvim_win_set_cursor(0, { 1, 10 })
+
+      config.set('enabled', false)
+      core.apply_decorations(bufnr)
+
+      local yank = require('camouflage.yank')
+      local reveal = require('camouflage.reveal')
+      local weak_secret = require('camouflage.checks.weak_secret')
+
+      assert.is_nil(yank.find_variable_at_cursor(bufnr))
+      reveal.reveal_line()
+      assert.is_false(reveal.is_revealed())
+      weak_secret.check_buffer(bufnr)
+      assert.is_nil(checks_store.get(bufnr, 0, 'weak_secret'))
 
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)

--- a/tests/camouflage/init_spec.lua
+++ b/tests/camouflage/init_spec.lua
@@ -141,6 +141,39 @@ describe('camouflage.init', function()
       assert.is_not_nil(found)
       assert.equals(0, #autocmds)
     end)
+
+    it('should not disable cmp for a supported buffer after masking stops', function()
+      local original_cmp = package.loaded.cmp
+      local disabled_calls = 0
+      package.loaded.cmp = {
+        setup = {
+          buffer = function(opts)
+            if opts and opts.enabled == false then
+              disabled_calls = disabled_calls + 1
+            end
+          end,
+        },
+      }
+      local bufnr = create_named_buffer({ 'API_KEY=secret' }, vim.fn.tempname() .. '.env')
+
+      camouflage.setup(no_network_opts())
+
+      local config = require('camouflage.config')
+      local core = require('camouflage.core')
+      local state = require('camouflage.state')
+      assert.is_true(state.is_buffer_masked(bufnr))
+
+      config.set('enabled', false)
+      core.apply_decorations(bufnr)
+      vim.api.nvim_exec_autocmds('BufEnter', { buffer = bufnr })
+
+      package.loaded.cmp = original_cmp
+
+      assert.is_false(state.is_buffer_masked(bufnr))
+      assert.equals(0, disabled_calls)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
   end)
 
   describe('enable/disable', function()

--- a/tests/camouflage/mask_extmark_spec.lua
+++ b/tests/camouflage/mask_extmark_spec.lua
@@ -114,6 +114,7 @@ describe('camouflage end-to-end extmark placement', function()
     local marks = vim.api.nvim_buf_get_extmarks(bufnr, state.namespace, 0, -1, {})
     assert.equals(0, #marks)
     assert.equals(0, #state.get_variables(bufnr))
+    assert.is_false(state.is_buffer_masked(bufnr))
 
     vim.api.nvim_buf_delete(bufnr, { force = true })
   end)


### PR DESCRIPTION
## Description

Fixes stale buffer mask state after `core.apply_decorations()` exits through a generic no-mask path.

Previously, `apply_decorations()` cleared mask extmarks before returning, but the shared no-mask reset helper did not set the buffer state back to unmasked. That meant a buffer could look unmasked while `state.is_buffer_masked(bufnr)` still returned true and stale variables could remain visible to later status, yank, reveal, check, or completion-related flows.

This updates the generic reset path so it leaves a coherent unmasked buffer state:

- `enabled = false`
- `variables = {}`
- generic policy stats cleared
- existing wrap restoration preserved

The all-policy-ignored path remains policy-specific, so policy statistics are still available while the buffer correctly reports as unmasked.

Regression coverage was added for these no-mask exits:

- global config disabled after a buffer was previously masked
- buffers growing past `max_lines`
- unsupported/no-parser outcomes
- parsers returning no variables
- buffer-local `vim.b.camouflage_enabled = false`
- stale yank, reveal, and check access after reset
- cmp integration after masking stops for a supported buffer

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Verification

- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/core_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/mask_extmark_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/init_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/follow_cursor_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/commands_spec.lua"`
- [x] `make test`
- [x] `make lint`
- [x] `make format`
- [x] `make format-check`

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

## Screenshots (if applicable)

N/A
