### PR TITLE
fix(core): clear state on global disable

### DIFF
--- a/lua/camouflage/core.lua
+++ b/lua/camouflage/core.lua
@@ -308,6 +308,14 @@ function M.clear_decorations(bufnr)
   end
 end
 
+---Clear all mask-owned buffer state without reparsing.
+---@param bufnr number|nil
+function M.clear_mask_state(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  M.clear_decorations(bufnr)
+  reset_mask_state(bufnr)
+end
+
 ---Refresh decorations for current buffer
 ---@return nil
 function M.refresh()

--- a/lua/camouflage/init.lua
+++ b/lua/camouflage/init.lua
@@ -446,10 +446,26 @@ function M.disable()
   require('camouflage.config').set('enabled', false)
   local state = require('camouflage.state')
   local core = require('camouflage.core')
+  local checks = require('camouflage.checks')
 
+  require('camouflage.reveal').hide()
+
+  local tracked_buffers = {}
   for bufnr, _ in pairs(state.buffers) do
+    table.insert(tracked_buffers, bufnr)
+  end
+
+  for _, bufnr in ipairs(tracked_buffers) do
     if vim.api.nvim_buf_is_valid(bufnr) then
-      core.clear_decorations(bufnr)
+      core.clear_mask_state(bufnr)
+    else
+      state.remove_buffer(bufnr)
+    end
+  end
+
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      checks.clear_buffer(bufnr)
     end
   end
 end

--- a/tests/camouflage/commands_spec.lua
+++ b/tests/camouflage/commands_spec.lua
@@ -7,9 +7,22 @@ describe('camouflage.commands', function()
     end
   end
 
+  local function create_env_buffer(lines)
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(bufnr, vim.fn.tempname() .. '.env')
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+    vim.api.nvim_set_current_buf(bufnr)
+    return bufnr
+  end
+
   before_each(function()
     clear_camouflage_modules()
-    require('camouflage').setup()
+    require('camouflage').setup({
+      pwned = { enabled = false },
+      checks = {
+        pwned = { enabled = false },
+      },
+    })
   end)
 
   it('should create CamouflageToggle command', function()
@@ -145,6 +158,32 @@ describe('camouflage.commands', function()
       assert.is_nil(message:find('status-secret-should-not-return', 1, true))
       vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
+
+    it('should report unmasked state after global disable clears stale variables', function()
+      local camouflage = require('camouflage')
+      local core = require('camouflage.core')
+      local bufnr = create_env_buffer({ 'API_KEY=status-stale-secret' })
+
+      core.apply_decorations(bufnr)
+      camouflage.disable()
+
+      local message
+      local original_notify = vim.notify
+      vim.notify = function(msg)
+        message = msg
+      end
+
+      vim.cmd('CamouflageStatus')
+
+      vim.notify = original_notify
+
+      assert.is_string(message)
+      assert.is_not_nil(message:find('Global: disabled', 1, true))
+      assert.is_not_nil(message:find('Buffer: not masked', 1, true))
+      assert.is_not_nil(message:find('Masked values: 0', 1, true))
+      assert.is_nil(message:find('status-stale-secret', 1, true))
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
   end)
 
   describe('CamouflageYank', function()
@@ -157,6 +196,26 @@ describe('camouflage.commands', function()
       end)
 
       vim.notify = original_notify
+    end)
+
+    it('should not copy stale values after global disable', function()
+      local camouflage = require('camouflage')
+      local core = require('camouflage.core')
+      local bufnr = create_env_buffer({ 'API_KEY=yank-stale-secret' })
+      vim.api.nvim_win_set_cursor(0, { 1, 10 })
+      core.apply_decorations(bufnr)
+      vim.fn.setreg('a', 'original')
+
+      local original_notify = vim.notify
+      vim.notify = function() end
+
+      camouflage.disable()
+      vim.cmd('CamouflageYank a')
+
+      vim.notify = original_notify
+
+      assert.equals('original', vim.fn.getreg('a'))
+      vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
   end)
 

--- a/tests/camouflage/core_spec.lua
+++ b/tests/camouflage/core_spec.lua
@@ -145,6 +145,27 @@ describe('camouflage.core', function()
     end)
   end)
 
+  describe('clear_mask_state', function()
+    it('should clear mask state, extmarks, policy stats, and restore wrap', function()
+      local bufnr = setup_buffer({ 'API_KEY=secret' })
+      local win = vim.api.nvim_get_current_win()
+      vim.api.nvim_set_option_value('wrap', true, { win = win })
+
+      core.apply_decorations(bufnr)
+      assert.is_true(state.is_buffer_masked(bufnr))
+      assert.is_true(#state.get_variables(bufnr) > 0)
+      assert.is_not_nil(state.get_policy_stats(bufnr))
+      assert.is_false(vim.api.nvim_get_option_value('wrap', { win = win }))
+
+      core.clear_mask_state(bufnr)
+
+      assert_unmasked_state(bufnr)
+      assert.is_true(vim.api.nvim_get_option_value('wrap', { win = win }))
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
+
   describe('is_masked', function()
     it('should return false when buffer has no state', function()
       local bufnr = vim.api.nvim_create_buf(false, true)

--- a/tests/camouflage/init_spec.lua
+++ b/tests/camouflage/init_spec.lua
@@ -10,29 +10,29 @@ describe('camouflage.init', function()
     end
   end
 
+  local function no_network_opts()
+    return {
+      pwned = { enabled = false },
+      checks = {
+        pwned = { enabled = false },
+      },
+    }
+  end
+
+  local function create_named_buffer(lines, filename)
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_name(bufnr, filename)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+    vim.api.nvim_set_current_buf(bufnr)
+    return bufnr
+  end
+
   before_each(function()
     clear_camouflage_modules()
     camouflage = require('camouflage')
   end)
 
   describe('setup', function()
-    local function no_network_opts()
-      return {
-        pwned = { enabled = false },
-        checks = {
-          pwned = { enabled = false },
-        },
-      }
-    end
-
-    local function create_named_buffer(lines, filename)
-      local bufnr = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_buf_set_name(bufnr, filename)
-      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
-      vim.api.nvim_set_current_buf(bufnr)
-      return bufnr
-    end
-
     it('should initialize without options', function()
       assert.has_no.errors(function()
         camouflage.setup()
@@ -180,7 +180,9 @@ describe('camouflage.init', function()
     before_each(function()
       clear_camouflage_modules()
       camouflage = require('camouflage')
-      camouflage.setup({ enabled = false })
+      local opts = no_network_opts()
+      opts.enabled = false
+      camouflage.setup(opts)
     end)
 
     it('should enable masking', function()
@@ -198,6 +200,79 @@ describe('camouflage.init', function()
       camouflage.disable()
 
       assert.is_false(camouflage.is_enabled())
+    end)
+
+    it('should synchronously clear buffer state, badges, reveal, and wrap', function()
+      camouflage.enable()
+      local bufnr = create_named_buffer({ 'PASSWORD=password' }, vim.fn.tempname() .. '.env')
+      local win = vim.api.nvim_get_current_win()
+      vim.api.nvim_set_option_value('wrap', true, { win = win })
+
+      local core = require('camouflage.core')
+      local state = require('camouflage.state')
+      local checks = require('camouflage.checks')
+      local badges = require('camouflage.checks.badges')
+      local store = require('camouflage.checks.store')
+      local reveal = require('camouflage.reveal')
+      local pwned_ui = require('camouflage.pwned.ui')
+
+      core.apply_decorations(bufnr)
+      checks.set_result(bufnr, 0, 'weak_secret', { severity = 'warning', text = '[weak]' })
+      checks.set_result(bufnr, 0, 'expiry', { severity = 'info', text = '[expires]' })
+      pwned_ui.mark_pwned(bufnr, 0, 5)
+
+      vim.api.nvim_win_set_cursor(0, { 1, 10 })
+      reveal.reveal_line()
+
+      local mask_marks = vim.api.nvim_buf_get_extmarks(bufnr, state.namespace, 0, -1, {})
+      local badge_marks = vim.api.nvim_buf_get_extmarks(bufnr, badges.get_namespace(), 0, -1, {})
+      assert.is_true(state.is_buffer_masked(bufnr))
+      assert.equals(1, #state.get_variables(bufnr))
+      assert.is_true(#mask_marks > 0)
+      assert.is_true(#badge_marks > 0)
+      assert.is_true(reveal.is_revealed())
+      assert.is_false(vim.api.nvim_get_option_value('wrap', { win = win }))
+
+      camouflage.disable()
+
+      mask_marks = vim.api.nvim_buf_get_extmarks(bufnr, state.namespace, 0, -1, {})
+      badge_marks = vim.api.nvim_buf_get_extmarks(bufnr, badges.get_namespace(), 0, -1, {})
+      assert.is_false(camouflage.is_enabled())
+      assert.is_false(state.is_buffer_masked(bufnr))
+      assert.equals(0, #state.get_variables(bufnr))
+      assert.equals(0, #mask_marks)
+      assert.equals(0, #badge_marks)
+      assert.is_nil(store.get(bufnr, 0, 'weak_secret'))
+      assert.is_nil(store.get(bufnr, 0, 'expiry'))
+      assert.is_nil(store.get(bufnr, 0, 'pwned'))
+      assert.is_false(reveal.is_revealed())
+      assert.is_true(vim.api.nvim_get_option_value('wrap', { win = win }))
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+
+    it('should reparse visible supported buffers after disable then enable', function()
+      camouflage.enable()
+      local bufnr = create_named_buffer({ 'API_KEY=old-secret' }, vim.fn.tempname() .. '.env')
+      local core = require('camouflage.core')
+      local state = require('camouflage.state')
+
+      core.apply_decorations(bufnr)
+      assert.is_true(state.is_buffer_masked(bufnr))
+      assert.equals('old-secret', state.get_variables(bufnr)[1].value)
+
+      camouflage.disable()
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'API_KEY=fresh-secret' })
+      camouflage.enable()
+
+      local variables = state.get_variables(bufnr)
+      local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, state.namespace, 0, -1, {})
+      assert.is_true(state.is_buffer_masked(bufnr))
+      assert.equals(1, #variables)
+      assert.equals('fresh-secret', variables[1].value)
+      assert.equals(1, #extmarks)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
     end)
 
     it('should toggle masking', function()


### PR DESCRIPTION
## Description

Fixes global disable leaving stale camouflage-owned state behind.

Previously, `require('camouflage').disable()` only cleared the mask extmark namespace. A buffer could look unmasked while still reporting `state.is_buffer_masked(bufnr) == true`, keeping stored variables available to status, yank, reveal, and check-related flows. Wrap changes and check badges could also remain after toggling camouflage off.

This change makes global disable a synchronous cleanup path:

- adds `core.clear_mask_state()` for mask extmarks, stored variables, masked state, policy stats, and wrap restoration
- updates `disable()` to use that cleanup for every valid tracked buffer
- removes invalid tracked buffer entries during disable
- clears centralized check store and badge namespaces for valid loaded buffers
- hides active reveal state when camouflage is disabled

Regression coverage was added for:

- direct `core.clear_mask_state()` behavior
- global disable clearing buffer state, mask extmarks, weak-secret/expiry/pwned badges, reveal state, and wrap changes
- `CamouflageStatus` reporting unmasked/zero values after disable
- `CamouflageYank` not copying stale values after disable
- `enable()` reparsing current visible buffer content after disable

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Verification

- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/core_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/init_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/commands_spec.lua"`
- [x] `make test`
- [x] `make lint`
- [x] `make format`
- [x] `make format-check`

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

## Screenshots (if applicable)

N/A
