### PR TITLE
fix(pwned): make HIBP auto checks opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Neovim plugin that visually masks secrets in `.env`, `.json`, `.yaml`, `.toml`
 - **Rule-Based Policy**: Data-only ignore/force-mask rules for paths, parsers, keys, metadata, and safe value shapes
 - **Weak Secret Check**: Offline badges for obvious defaults, placeholders, short values, repeated values, and low-entropy tokens
 - **Custom Check API**: Register trusted Lua checks that render through the shared badge pipeline
-- **Have I Been Pwned**: Check passwords against breach database (Neovim 0.10+ with `vim.system`, plus `curl`)
+- **Have I Been Pwned**: Manually check passwords against the breach database (network checks are opt-in; Neovim 0.10+ with `vim.system`, plus `curl`)
 - **JWT Expiry Hints**: Decode `exp` claim and show "expires in 2h" badges
 - **Hot Reload**: Config changes apply immediately
 - **Event System**: Hooks for extending functionality
@@ -59,6 +59,13 @@ For per-repo `.camouflage.yaml` files, masking config is applied as data only
 (no code execution). If you don't trust the repositories you open, set
 `project_config.secure = true` to gate the file behind Neovim's
 `vim.secure`/`:trust` mechanism.
+
+Have I Been Pwned checks use the network. They are manual/opt-in by default:
+the `:CamouflagePwnedCheck*` commands remain available, but automatic checks on
+buffer enter, save, or text change are disabled unless you set the corresponding
+`pwned` option to `true`. The HIBP integration uses k-anonymity and sends only
+the first 5 characters of a SHA-1 hash, but this is still a deliberate network
+request.
 
 The `scramble` style is **cosmetic, not protective**: the mask is a shuffle of
 the real characters, so it leaks the value's length and character set.
@@ -177,6 +184,13 @@ require('camouflage').setup({
     },
   },
 
+  pwned = {
+    enabled = true,          -- Manual HIBP commands are available
+    auto_check = false,      -- Network check on BufEnter (opt in)
+    check_on_save = false,   -- Network check on BufWritePost (opt in)
+    check_on_change = false, -- Network check on TextChanged (opt in)
+  },
+
   reveal = {
     follow_cursor = false,   -- Auto-reveal current line
   },
@@ -209,7 +223,10 @@ require('camouflage').setup({
 | `:CamouflageAudit! [path]` | Scan workspace/path and populate location list |
 | `:CamouflageWeakSecretToggle` | Toggle offline weak-secret badges |
 | `:CamouflagePwnedCheck` | Check if value under cursor is pwned |
+| `:CamouflagePwnedCheckLine` | Check all values on current line |
 | `:CamouflagePwnedCheckBuffer` | Check all values in buffer |
+| `:CamouflagePwnedClear` | Clear pwned indicators from buffer |
+| `:CamouflagePwnedClearCache` | Clear local pwned check cache |
 | `:CamouflageExpiryToggle` | Toggle JWT expiry check on/off |
 | `:CamouflageInit` | Create `.camouflage.yaml` in project root |
 | `:CamouflageParsers` | List registered parsers (debug) |

--- a/doc/camouflage.txt
+++ b/doc/camouflage.txt
@@ -90,6 +90,8 @@ For Have I Been Pwned feature (|camouflage-pwned|):
 - Neovim >= 0.10.0 (requires `vim.system`)
 - `curl` (for API requests)
   (password hashing is done in-process; no external sha1sum/openssl needed)
+- HIBP uses network requests; automatic checks are disabled by default and must
+  be opted into explicitly.
 
 ==============================================================================
 INSTALLATION                                          *camouflage-installation*
@@ -231,9 +233,9 @@ Call the setup function with your options: >lua
     -- Have I Been Pwned (requires Neovim 0.10+ with vim.system, plus curl)
     pwned = {
       enabled = true,             -- Enable the feature
-      auto_check = true,          -- Check on BufEnter
-      check_on_save = true,       -- Check on BufWritePost
-      check_on_change = true,     -- Check when value changes
+      auto_check = false,         -- Network check on BufEnter (opt in)
+      check_on_save = false,      -- Network check on BufWritePost (opt in)
+      check_on_change = false,    -- Network check when value changes (opt in)
       show_sign = true,           -- Show sign column indicator
       show_virtual_text = true,   -- Show virtual text
       show_line_highlight = true, -- Highlight the line
@@ -1488,6 +1490,10 @@ The integration uses k-anonymity: only the first 5 characters of the
 SHA-1 hash are sent to the HIBP API. Your actual passwords never leave
 your machine.
 
+HIBP is still a network check. Manual commands are available by default, but
+automatic checks on buffer enter, save, and text change are disabled unless you
+explicitly opt in with the corresponding `pwned` options.
+
 How it works:
 1. Password is hashed locally using SHA-1
 2. Only the first 5 characters of the hash are sent to the API
@@ -1508,8 +1514,9 @@ Configuration ~
   require('camouflage').setup({
     pwned = {
       enabled = true,               -- Feature toggle
-      auto_check = true,            -- Check on BufEnter
-      check_on_save = true,         -- Check on BufWritePost
+      auto_check = false,           -- Network check on BufEnter (opt in)
+      check_on_save = false,        -- Network check on BufWritePost (opt in)
+      check_on_change = false,      -- Network check on TextChanged (opt in)
       show_sign = true,             -- Show sign column indicator
       show_virtual_text = true,     -- Show virtual text
       show_line_highlight = true,   -- Highlight the line

--- a/lua/camouflage/autocmds.lua
+++ b/lua/camouflage/autocmds.lua
@@ -180,6 +180,7 @@ function M.setup()
     vim.api.nvim_create_autocmd('BufEnter', {
       group = group,
       pattern = all_patterns,
+      desc = 'Camouflage pwned check on buffer enter',
       callback = function(args)
         if vim.api.nvim_buf_is_valid(args.buf) then
           vim.schedule(function()
@@ -198,6 +199,7 @@ function M.setup()
     vim.api.nvim_create_autocmd('BufWritePost', {
       group = group,
       pattern = all_patterns,
+      desc = 'Camouflage pwned check on save',
       callback = function(args)
         if vim.api.nvim_buf_is_valid(args.buf) then
           vim.schedule(function()
@@ -216,6 +218,7 @@ function M.setup()
     vim.api.nvim_create_autocmd({ 'TextChanged', 'TextChangedI' }, {
       group = group,
       pattern = all_patterns,
+      desc = 'Camouflage pwned check on text change',
       callback = function(args)
         if vim.api.nvim_buf_is_valid(args.buf) then
           cleanup_pwned_timer(args.buf)

--- a/lua/camouflage/config.lua
+++ b/lua/camouflage/config.lua
@@ -68,9 +68,9 @@ local M = {}
 
 ---@class CamouflagePwnedConfig
 ---@field enabled? boolean Feature toggle (default: true)
----@field auto_check? boolean Check on BufEnter (default: true)
----@field check_on_save? boolean Check on BufWritePost (default: true)
----@field check_on_change? boolean Check on TextChanged with debounce (default: true)
+---@field auto_check? boolean Check on BufEnter (default: false; network opt-in)
+---@field check_on_save? boolean Check on BufWritePost (default: false; network opt-in)
+---@field check_on_change? boolean Check on TextChanged with debounce (default: false; network opt-in)
 ---@field show_sign? boolean Show sign column indicator (default: true)
 ---@field show_virtual_text? boolean Show virtual text (default: true)
 ---@field show_line_highlight? boolean Highlight the line (default: true)
@@ -258,9 +258,9 @@ M.defaults = {
   },
   pwned = {
     enabled = true,
-    auto_check = true,
-    check_on_save = true,
-    check_on_change = true,
+    auto_check = false,
+    check_on_save = false,
+    check_on_change = false,
     show_sign = true,
     show_virtual_text = true,
     show_line_highlight = true,
@@ -428,7 +428,7 @@ end
 ---@param opts CamouflageConfig|nil
 function M.setup(opts)
   local user_opts = validate_config(opts) or {}
-  M.user_options = vim.tbl_deep_extend('force', {}, user_opts)
+  M.user_options = vim.deepcopy(user_opts)
 
   -- Merge user project_config with defaults to get effective settings
   local effective_project_config = vim.tbl_deep_extend(
@@ -438,7 +438,13 @@ function M.setup(opts)
     M.user_options.project_config or {}
   )
   local project_config_opts = require('camouflage.project_config').load(effective_project_config)
-  M.options = vim.tbl_deep_extend('force', {}, M.defaults, M.user_options, project_config_opts)
+  M.options = vim.tbl_deep_extend(
+    'force',
+    {},
+    vim.deepcopy(M.defaults),
+    vim.deepcopy(M.user_options),
+    vim.deepcopy(project_config_opts)
+  )
   apply_legacy_aliases(M.options)
   warn_cosmetic_styles(M.options)
 end
@@ -457,7 +463,13 @@ function M.reload_project_config()
     return false, status
   end
 
-  M.options = vim.tbl_deep_extend('force', {}, M.defaults, M.user_options, project_config_opts)
+  M.options = vim.tbl_deep_extend(
+    'force',
+    {},
+    vim.deepcopy(M.defaults),
+    vim.deepcopy(M.user_options),
+    vim.deepcopy(project_config_opts)
+  )
   apply_legacy_aliases(M.options)
   warn_cosmetic_styles(M.options)
   return true, status

--- a/lua/camouflage/templates/project_config.yaml
+++ b/lua/camouflage/templates/project_config.yaml
@@ -277,21 +277,23 @@ reveal:
 # HAVE I BEEN PWNED (HIBP) INTEGRATION
 # =============================================================================
 
-# Check passwords against the HIBP breach database
+# Check passwords against the HIBP breach database.
+# This is a network check; manual commands are available by default, but
+# automatic checks are disabled unless you opt in below.
 # Requires: Neovim 0.10+, curl
 # Privacy: Uses k-anonymity (only first 5 chars of SHA-1 hash sent)
 pwned:
-  # Enable the feature
+  # Enable the feature and manual commands
   enabled: true
 
-  # Check passwords on BufEnter
-  auto_check: true
+  # Network check passwords on BufEnter (opt in)
+  auto_check: false
 
-  # Check passwords on save
-  check_on_save: true
+  # Network check passwords on save (opt in)
+  check_on_save: false
 
-  # Check passwords on text change (with debounce)
-  check_on_change: true
+  # Network check passwords on text change with debounce (opt in)
+  check_on_change: false
 
   # Show sign column indicator for breached passwords
   show_sign: true

--- a/tests/camouflage/autocmds_spec.lua
+++ b/tests/camouflage/autocmds_spec.lua
@@ -10,6 +10,20 @@ describe('camouflage.autocmds', function()
     end
   end
 
+  local function pwned_autocmds(event)
+    local query = { group = state.augroup }
+    if event then
+      query.event = event
+    end
+    local results = {}
+    for _, au in ipairs(vim.api.nvim_get_autocmds(query)) do
+      if au.desc and au.desc:find('Camouflage pwned', 1, true) then
+        table.insert(results, au)
+      end
+    end
+    return results
+  end
+
   before_each(function()
     clear_camouflage_modules()
     require('camouflage.config').setup()
@@ -72,6 +86,57 @@ describe('camouflage.autocmds', function()
       })
 
       assert.is_true(#aus > 0)
+    end)
+
+    it('should not create HIBP network-check autocmds by default', function()
+      autocmds.setup()
+
+      assert.equals(0, #pwned_autocmds())
+    end)
+
+    it('should only create the opted-in HIBP BufEnter autocmd', function()
+      require('camouflage.config').setup({
+        pwned = {
+          auto_check = true,
+        },
+      })
+
+      autocmds.setup()
+
+      assert.is_true(#pwned_autocmds('BufEnter') > 0)
+      assert.equals(0, #pwned_autocmds('BufWritePost'))
+      assert.equals(0, #pwned_autocmds('TextChanged'))
+      assert.equals(0, #pwned_autocmds('TextChangedI'))
+    end)
+
+    it('should only create the opted-in HIBP BufWritePost autocmd', function()
+      require('camouflage.config').setup({
+        pwned = {
+          check_on_save = true,
+        },
+      })
+
+      autocmds.setup()
+
+      assert.equals(0, #pwned_autocmds('BufEnter'))
+      assert.is_true(#pwned_autocmds('BufWritePost') > 0)
+      assert.equals(0, #pwned_autocmds('TextChanged'))
+      assert.equals(0, #pwned_autocmds('TextChangedI'))
+    end)
+
+    it('should only create the opted-in HIBP text-change autocmds', function()
+      require('camouflage.config').setup({
+        pwned = {
+          check_on_change = true,
+        },
+      })
+
+      autocmds.setup()
+
+      assert.equals(0, #pwned_autocmds('BufEnter'))
+      assert.equals(0, #pwned_autocmds('BufWritePost'))
+      assert.is_true(#pwned_autocmds('TextChanged') > 0)
+      assert.is_true(#pwned_autocmds('TextChangedI') > 0)
     end)
   end)
 

--- a/tests/camouflage/commands_spec.lua
+++ b/tests/camouflage/commands_spec.lua
@@ -60,6 +60,15 @@ describe('camouflage.commands', function()
     assert.is_not_nil(commands['CamouflageReveal'])
   end)
 
+  it('should create pwned manual check commands', function()
+    local commands = vim.api.nvim_get_commands({})
+    assert.is_not_nil(commands['CamouflagePwnedCheck'])
+    assert.is_not_nil(commands['CamouflagePwnedCheckLine'])
+    assert.is_not_nil(commands['CamouflagePwnedCheckBuffer'])
+    assert.is_not_nil(commands['CamouflagePwnedClear'])
+    assert.is_not_nil(commands['CamouflagePwnedClearCache'])
+  end)
+
   describe('CamouflageToggle', function()
     it('should toggle enabled state', function()
       local camouflage = require('camouflage')
@@ -229,6 +238,37 @@ describe('camouflage.commands', function()
       end)
 
       vim.notify = original_notify
+    end)
+  end)
+
+  describe('CamouflagePwned manual commands', function()
+    it('should dispatch to pwned entrypoints without automatic triggers', function()
+      local calls = {
+        current = 0,
+        line = 0,
+        buffer = 0,
+      }
+      package.loaded['camouflage.pwned'] = {
+        check_current = function()
+          calls.current = calls.current + 1
+        end,
+        check_line = function()
+          calls.line = calls.line + 1
+        end,
+        check_buffer = function()
+          calls.buffer = calls.buffer + 1
+        end,
+        clear = function() end,
+        clear_cache = function() end,
+      }
+
+      vim.cmd('CamouflagePwnedCheck')
+      vim.cmd('CamouflagePwnedCheckLine')
+      vim.cmd('CamouflagePwnedCheckBuffer')
+
+      assert.equals(1, calls.current)
+      assert.equals(1, calls.line)
+      assert.equals(1, calls.buffer)
     end)
   end)
 end)

--- a/tests/camouflage/config_spec.lua
+++ b/tests/camouflage/config_spec.lua
@@ -43,6 +43,44 @@ describe('camouflage.config', function()
       assert.same({}, policy.rules)
     end)
 
+    it('keeps HIBP available but disables automatic network checks by default', function()
+      config.setup()
+      local pwned = config.get().pwned
+
+      assert.is_true(pwned.enabled)
+      assert.is_false(pwned.auto_check)
+      assert.is_false(pwned.check_on_save)
+      assert.is_false(pwned.check_on_change)
+    end)
+
+    it('allows opting in to individual HIBP automatic triggers', function()
+      config.setup({
+        pwned = {
+          check_on_save = true,
+        },
+      })
+      local pwned = config.get().pwned
+
+      assert.is_false(pwned.auto_check)
+      assert.is_true(pwned.check_on_save)
+      assert.is_false(pwned.check_on_change)
+    end)
+
+    it('does not let legacy pwned aliasing mutate defaults across setup calls', function()
+      config.setup()
+      assert.is_nil(config.defaults.checks.pwned)
+
+      config.setup({
+        pwned = {
+          auto_check = true,
+        },
+      })
+
+      assert.is_nil(config.defaults.checks.pwned)
+      assert.is_true(config.get().pwned.auto_check)
+      assert.is_true(config.get().checks.pwned.auto_check)
+    end)
+
     it('should merge user policy options with defaults', function()
       config.setup({
         policy = {


### PR DESCRIPTION
## Description

Makes HIBP network checks opt-in by default while keeping manual pwned commands available.

Previously, the default pwned config enabled automatic checks on buffer enter, save, and text change. Even though the HIBP integration uses k-anonymity and only sends the first 5 SHA-1 hash characters, opening or editing a secret file could still start a network request without an explicit user action.

This changes the default behavior to avoid implicit HIBP network egress:

- keeps `pwned.enabled = true` so manual commands remain available
- sets `pwned.auto_check = false`
- sets `pwned.check_on_save = false`
- sets `pwned.check_on_change = false`
- keeps opt-in support for each automatic trigger independently
- adds descriptions to pwned autocmds so tests can distinguish HIBP network-triggering autocmds from normal masking autocmds
- fixes config default table aliasing so the legacy `pwned` key and canonical `checks.pwned` alias do not mutate defaults across setup calls or erase later opt-in values

Docs and templates now call out that HIBP is a network check, that automatic triggers are disabled by default, and that users can opt in explicitly.

Regression coverage was added for:

- default pwned config leaving automatic network checks disabled
- opting in to one automatic trigger without enabling the others
- default setup registering no HIBP network-check autocmds
- opt-in setup registering only the selected HIBP trigger family
- manual `CamouflagePwned*` commands remaining registered and dispatching to pwned entrypoints
- config aliasing not mutating defaults across setup calls

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Verification

- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/config_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/autocmds_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/commands_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/pwned/init_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/pwned/api_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/pwned/cache_spec.lua"`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/pwned/hash_spec.lua"`
- [x] `rg "auto_check = true|check_on_save = true|check_on_change = true|auto_check: true|check_on_save: true|check_on_change: true" -n README.md doc/camouflage.txt lua/camouflage/templates/project_config.yaml lua/camouflage/config.lua`
- [x] `make test`
- [x] `make lint`
- [x] `make format`
- [x] `make format-check`

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

## Screenshots (if applicable)

N/A
