### PR TITLE
fix(core): use buffer-local mask config

### DIFF
--- a/lua/camouflage/core.lua
+++ b/lua/camouflage/core.lua
@@ -225,7 +225,7 @@ function M.apply_single_decoration(bufnr, var, cfg, lines, line_offsets)
   else
     -- Single line value (mask sized by display cells, not bytes)
     local masked_text =
-      styles.generate_hidden_text(cfg.style, vim.fn.strdisplaywidth(var.value), var.value)
+      styles.generate_hidden_text(cfg.style, vim.fn.strdisplaywidth(var.value), var.value, cfg)
     local ok, err =
       pcall(vim.api.nvim_buf_set_extmark, bufnr, state.namespace, start_pos.row, start_pos.col, {
         end_row = end_pos.row,
@@ -281,8 +281,12 @@ function M.apply_multiline_decoration(bufnr, var, cfg, lines, start_pos, end_pos
       goto continue
     end
 
-    local masked_text =
-      styles.generate_hidden_text(cfg.style, vim.fn.strdisplaywidth(line_content), line_content)
+    local masked_text = styles.generate_hidden_text(
+      cfg.style,
+      vim.fn.strdisplaywidth(line_content),
+      line_content,
+      cfg
+    )
     local ok, err = pcall(vim.api.nvim_buf_set_extmark, bufnr, state.namespace, row, col_start, {
       end_row = row,
       end_col = col_end,

--- a/tests/camouflage/mask_extmark_spec.lua
+++ b/tests/camouflage/mask_extmark_spec.lua
@@ -28,6 +28,21 @@ describe('camouflage end-to-end extmark placement', function()
     return row, byte_index - line_start
   end
 
+  local function mask_texts(bufnr)
+    local marks = vim.api.nvim_buf_get_extmarks(bufnr, state.namespace, 0, -1, {
+      details = true,
+    })
+    local texts = {}
+    for _, mark in ipairs(marks) do
+      table.insert(texts, {
+        row = mark[2],
+        col = mark[3],
+        text = mark[4].virt_text[1][1],
+      })
+    end
+    return texts
+  end
+
   it('places overlay extmarks exactly on each value range', function()
     local lines = { 'API_KEY=secret123', 'DB_PASSWORD=hunter2' }
     local content = table.concat(lines, '\n')
@@ -60,6 +75,70 @@ describe('camouflage end-to-end extmark placement', function()
         string.format('no extmark at expected (%d, %d) for key %s', srow, scol, var.key)
       )
     end
+
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end)
+
+  it('uses buffer-local mask_char when rendering stars masks', function()
+    local bufnr = vim.api.nvim_create_buf(true, false)
+    vim.api.nvim_buf_set_name(bufnr, '/tmp/camouflage_test/local-char.env')
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'API_KEY=secret123' })
+    vim.b[bufnr].camouflage_mask_char = '#'
+
+    core.apply_decorations(bufnr)
+
+    local texts = mask_texts(bufnr)
+    assert.equals(1, #texts)
+    assert.equals('#########', texts[1].text)
+
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end)
+
+  it('uses buffer-local mask_length and pads to cover the value width', function()
+    local bufnr = vim.api.nvim_create_buf(true, false)
+    vim.api.nvim_buf_set_name(bufnr, '/tmp/camouflage_test/local-length.env')
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { 'API_KEY=secret123' })
+    vim.b[bufnr].camouflage_mask_length = 4
+
+    core.apply_decorations(bufnr)
+
+    local texts = mask_texts(bufnr)
+    assert.equals(1, #texts)
+    assert.equals('****' .. string.rep(' ', 5), texts[1].text)
+    assert.equals(vim.fn.strdisplaywidth('secret123'), vim.fn.strdisplaywidth(texts[1].text))
+
+    vim.api.nvim_buf_delete(bufnr, { force = true })
+  end)
+
+  it('uses buffer-local rendering config for multiline masks', function()
+    local lines = { 'PRIVATE_KEY=line-one', '  line-two' }
+    local bufnr = vim.api.nvim_create_buf(true, false)
+    vim.api.nvim_buf_set_name(bufnr, '/tmp/camouflage_test/local-multiline.env')
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+    vim.b[bufnr].camouflage_mask_char = '#'
+
+    local content = table.concat(lines, '\n')
+    local start_index = #'PRIVATE_KEY='
+    local var = {
+      key = 'PRIVATE_KEY',
+      value = 'line-one\n  line-two',
+      start_index = start_index,
+      end_index = #content,
+      is_multiline = true,
+    }
+
+    core.apply_single_decoration(
+      bufnr,
+      var,
+      config.get_for_buffer(bufnr),
+      lines,
+      core.compute_line_offsets(lines)
+    )
+
+    local texts = mask_texts(bufnr)
+    assert.equals(2, #texts)
+    assert.equals('########', texts[1].text)
+    assert.equals('########', texts[2].text)
 
     vim.api.nvim_buf_delete(bufnr, { force = true })
   end)


### PR DESCRIPTION
## Description

This fixes buffer-local mask rendering overrides being ignored by the core decoration path.

`config.get_for_buffer()` already merges buffer-local settings like `vim.b.camouflage_mask_char` and `vim.b.camouflage_mask_length`, but `core.apply_single_decoration()` and the multiline decoration path called `styles.generate_hidden_text()` without passing that effective buffer config. As a result, rendered virtual text fell back to global mask settings even when buffer-local overrides were present.

Changes included:

- Pass the effective `cfg` into `styles.generate_hidden_text()` for single-line masks.
- Pass the same effective `cfg` into multiline per-line mask rendering.
- Add extmark-level regressions for buffer-local `mask_char`, short `mask_length` padding, and multiline rendering.

## Related Issue

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format-check`
- [x] I have added tests that prove my fix works
- [x] All new and existing tests pass (`make test`)
- [x] Documentation is not needed for this internal rendering fix
- [x] My commit messages follow conventional commits format

## Verification

- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/mask_extmark_spec.lua"`
  - Failed before the fix with global `*` masks for buffer-local overrides.
  - Passed after the fix: 7 successes, 0 failures.
- `make test`
- `make lint`
- `make format-check`

## Screenshots

Not applicable.
