### PR TITLE
docs: align lazy.nvim load event guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ the real characters, so it leaks the value's length and character set.
 ```lua
 {
   'zeybek/camouflage.nvim',
-  event = 'VeryLazy',
+  event = { 'BufReadPre', 'BufNewFile' },
   opts = {},
   keys = {
     { '<leader>ct', '<cmd>CamouflageToggle<cr>', desc = 'Toggle Camouflage' },
@@ -87,6 +87,11 @@ the real characters, so it leaks the value's length and character set.
   },
 }
 ```
+
+Use `BufReadPre`/`BufNewFile` when you want masking available as files are
+opened. `VeryLazy` is also usable if you prefer deferred startup loading, but it
+can let a buffer appear before the first masking pass runs. camouflage only masks
+visually; it does not encrypt, remove, or otherwise secure the real buffer text.
 
 <details>
 <summary>Other package managers</summary>

--- a/doc/camouflage.txt
+++ b/doc/camouflage.txt
@@ -107,6 +107,12 @@ Using lazy.nvim: >lua
   }
 <
 
+Use `BufReadPre` / `BufNewFile` when you want masking available as files are
+opened. `VeryLazy` is also usable if you prefer deferred startup loading, but it
+can let a buffer appear before the first masking pass runs. camouflage only
+masks visually; it does not encrypt, remove, or otherwise secure the real buffer
+text.
+
 Using packer.nvim: >lua
   use {
     'zeybek/camouflage.nvim',


### PR DESCRIPTION
## Description

This aligns the lazy.nvim installation guidance between `README.md` and `doc/camouflage.txt`.

The README previously recommended `event = 'VeryLazy'`, while the Vim help recommended `event = { 'BufReadPre', 'BufNewFile' }`. Since camouflage is meant to reduce on-screen exposure of sensitive values, the primary install snippet should favor loading before files are shown instead of deferred startup loading.

Changes included:

- Updated the README lazy.nvim example to use `BufReadPre` / `BufNewFile`.
- Kept the Vim help primary example on the same event recommendation.
- Added a short note in both docs explaining that `VeryLazy` is still usable as a deferred-loading choice, but may allow a buffer to appear before the first masking pass runs.
- Repeated that camouflage is visual masking only and does not encrypt, remove, or otherwise secure the real buffer text.

## Related Issue

None.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format-check`
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

## Verification

- `rg -n "VeryLazy|BufReadPre|BufNewFile" README.md doc/camouflage.txt`
- `rg -n "visual|does not encrypt|does NOT encrypt|grep|yank" README.md doc/camouflage.txt`
- `make test`
- `make lint`
- `make format-check`
- `git diff --check`
- Help sanity check with temporary runtimepath, `:helptags`, and `:help camouflage-installation`

## Screenshots

Not applicable.
