### PR TITLE
docs: update project template parser coverage

### DIFF
--- a/lua/camouflage/init_command.lua
+++ b/lua/camouflage/init_command.lua
@@ -12,9 +12,12 @@ local function get_plugin_path()
   if source:sub(1, 1) == '@' then
     source = source:sub(2)
   end
+  source = vim.fn.fnamemodify(source, ':p')
   -- Go up from lua/camouflage/init_command.lua to plugin root
   return vim.fn.fnamemodify(source, ':h:h:h')
 end
+
+local plugin_path_at_load = get_plugin_path()
 
 --- Read the template file
 ---@return string|nil content, string|nil error
@@ -27,7 +30,7 @@ local function read_template()
   if rtp and rtp[1] then
     template_path = rtp[1]
   else
-    local plugin_path = get_plugin_path()
+    local plugin_path = plugin_path_at_load or get_plugin_path()
     if not plugin_path then
       return nil, 'Could not determine plugin path'
     end
@@ -38,7 +41,17 @@ local function read_template()
 
   local ok, lines = pcall(vim.fn.readfile, template_path)
   if not ok or type(lines) ~= 'table' then
-    return nil, 'Could not read template file'
+    local plugin_path = plugin_path_at_load or get_plugin_path()
+    local fallback_path = plugin_path
+        and (plugin_path .. '/lua/camouflage/templates/project_config.yaml')
+      or nil
+    if fallback_path and fallback_path ~= template_path then
+      log.debug('Retrying template read from: %s', fallback_path)
+      ok, lines = pcall(vim.fn.readfile, fallback_path)
+    end
+    if not ok or type(lines) ~= 'table' then
+      return nil, 'Could not read template file'
+    end
   end
 
   return table.concat(lines, '\n'), nil

--- a/lua/camouflage/templates/project_config.yaml
+++ b/lua/camouflage/templates/project_config.yaml
@@ -71,7 +71,7 @@ highlight_group: Comment
 # =============================================================================
 
 # Define which files should be parsed and with which parser
-# Available parsers: env, json, yaml, toml, properties, netrc, xml, http
+# Available parsers: env, json, yaml, toml, properties, netrc, xml, http, hcl, dockerfile
 patterns:
   - file_pattern: ['.env*', '*.env', '.envrc']
     parser: env
@@ -91,6 +91,10 @@ patterns:
     parser: xml
   - file_pattern: ['*.http']
     parser: http
+  - file_pattern: ['*.tf', '*.tfvars', '*.hcl']
+    parser: hcl
+  - file_pattern: ['Dockerfile', 'Dockerfile.*', '*.dockerfile', 'Containerfile', 'Containerfile.*']
+    parser: dockerfile
 
 # =============================================================================
 # CUSTOM PATTERNS
@@ -128,6 +132,18 @@ parsers:
   # YAML parser settings
   yaml:
     max_depth: 10
+
+  # XML parser settings
+  xml:
+    max_depth: 10
+
+  # HCL/Terraform parser settings
+  hcl:
+    max_depth: 10
+
+  # Dockerfile parser settings
+  dockerfile:
+    # No parser-specific options currently
 
 # =============================================================================
 # INTEGRATIONS

--- a/tests/camouflage/init_command_spec.lua
+++ b/tests/camouflage/init_command_spec.lua
@@ -9,6 +9,17 @@ describe('camouflage.init_command', function()
     end
   end
 
+  local function capture_notify()
+    local calls = {}
+    local original_notify = vim.notify
+    vim.notify = function(msg, level)
+      table.insert(calls, { msg = msg, level = level })
+    end
+    return calls, function()
+      vim.notify = original_notify
+    end
+  end
+
   before_each(function()
     clear_camouflage_modules()
     require('camouflage').setup()
@@ -50,6 +61,44 @@ describe('camouflage.init_command', function()
       assert.is_not_nil(content)
       assert.is_true(content:match('version: 1') ~= nil)
     end)
+
+    it('should document all built-in parser names and default project patterns', function()
+      local content, _ = init_command._read_template()
+      assert.is_not_nil(content)
+
+      for _, parser in ipairs({
+        'env',
+        'json',
+        'yaml',
+        'toml',
+        'properties',
+        'netrc',
+        'xml',
+        'http',
+        'hcl',
+        'dockerfile',
+      }) do
+        assert.is_not_nil(content:find(parser, 1, true), 'missing parser: ' .. parser)
+      end
+
+      assert.is_not_nil(content:find("file_pattern: ['*.tf', '*.tfvars', '*.hcl']", 1, true))
+      assert.is_not_nil(content:find("'Dockerfile'", 1, true))
+      assert.is_not_nil(content:find("'Dockerfile.*'", 1, true))
+      assert.is_not_nil(content:find("'*.dockerfile'", 1, true))
+      assert.is_not_nil(content:find("'Containerfile'", 1, true))
+      assert.is_not_nil(content:find("'Containerfile.*'", 1, true))
+      assert.is_not_nil(content:find('parser: dockerfile', 1, true))
+    end)
+
+    it('should include schema-supported parser settings examples', function()
+      local content, _ = init_command._read_template()
+      assert.is_not_nil(content)
+
+      assert.is_not_nil(content:find('xml:', 1, true))
+      assert.is_not_nil(content:find('hcl:', 1, true))
+      assert.is_not_nil(content:find('dockerfile:', 1, true))
+      assert.is_not_nil(content:find('No parser-specific options currently', 1, true))
+    end)
   end)
 
   describe('_get_project_root', function()
@@ -80,35 +129,30 @@ describe('camouflage.init_command', function()
     end)
 
     it('should create file in test directory', function()
-      -- Suppress notifications
-      local original_notify = vim.notify
-      vim.notify = function() end
+      local notify_calls, restore_notify = capture_notify()
+      local result = init_command.init({ force = true, open = false })
+      restore_notify()
 
-      local result = init_command.init({ open = false })
-
-      vim.notify = original_notify
-
-      assert.is_true(result)
+      assert.is_true(result, vim.inspect(notify_calls))
 
       local target = test_dir .. '/.camouflage.yaml'
       assert.equals(1, vim.fn.filereadable(target))
     end)
 
     it('should create file with correct content', function()
-      -- Suppress notifications
-      local original_notify = vim.notify
-      vim.notify = function() end
+      local notify_calls, restore_notify = capture_notify()
+      local result = init_command.init({ force = true, open = false })
+      restore_notify()
 
-      init_command.init({ open = false })
-
-      vim.notify = original_notify
-
+      assert.is_true(result, vim.inspect(notify_calls))
       local target = test_dir .. '/.camouflage.yaml'
       local lines = vim.fn.readfile(target)
       local content = table.concat(lines, '\n')
 
       assert.is_true(content:match('^# yaml%-language%-server') ~= nil)
       assert.is_true(content:match('version: 1') ~= nil)
+      assert.is_not_nil(content:find("file_pattern: ['*.tf', '*.tfvars', '*.hcl']", 1, true))
+      assert.is_not_nil(content:find('parser: dockerfile', 1, true))
     end)
   end)
 

--- a/tests/camouflage/project_config_spec.lua
+++ b/tests/camouflage/project_config_spec.lua
@@ -54,6 +54,35 @@ describe('camouflage.project_config', function()
     assert.is_true(config.get().debug)
   end)
 
+  it('should load generated template with current built-in parser coverage', function()
+    local dir = vim.fn.tempname()
+    vim.fn.mkdir(dir, 'p')
+    local template = require('camouflage.init_command')._read_template()
+    vim.fn.writefile(vim.split(template, '\n', { plain = true }), dir .. '/.camouflage.yaml')
+    vim.cmd('cd ' .. vim.fn.fnameescape(dir))
+
+    config.setup()
+    local status = project_config.status()
+    local patterns_by_parser = {}
+    for _, entry in ipairs(config.get().patterns) do
+      patterns_by_parser[entry.parser] = entry.file_pattern
+    end
+
+    assert.is_true(status.loaded)
+    assert.equals(0, #status.errors)
+    assert.same({ '*.tf', '*.tfvars', '*.hcl' }, patterns_by_parser.hcl)
+    assert.same({
+      'Dockerfile',
+      'Dockerfile.*',
+      '*.dockerfile',
+      'Containerfile',
+      'Containerfile.*',
+    }, patterns_by_parser.dockerfile)
+    assert.equals(10, config.get().parsers.xml.max_depth)
+    assert.equals(10, config.get().parsers.hcl.max_depth)
+    assert.same({}, config.get().parsers.dockerfile)
+  end)
+
   it('should accept documented nil-default keys (e.g. mask_length)', function()
     -- mask_length has a nil default, so its type cannot be inferred from
     -- defaults; the NULLABLE_KEYS allowlist must accept it instead of rejecting


### PR DESCRIPTION
## Description

This updates the generated `.camouflage.yaml` project config template so it matches the built-in parser coverage documented and registered by the plugin.

The template previously listed only the older parser set and omitted HCL/Terraform and Dockerfile/Containerfile examples, even though runtime defaults, README/help docs, and the project config schema already support those areas.

Changes included:

- Added `hcl` and `dockerfile` to the template's available parser list.
- Added runtime-equivalent project pattern examples for `*.tf`, `*.tfvars`, `*.hcl`, `Dockerfile`, `Dockerfile.*`, `*.dockerfile`, `Containerfile`, and `Containerfile.*`.
- Added concise parser settings examples for XML, HCL, and Dockerfile using schema-supported keys only.
- Extended init/template and project config tests so generated output includes the current parser coverage and still loads as a valid project config.
- Made `CamouflageInit` template lookup more robust after `:cd` by falling back to the plugin path captured at module load when runtimepath lookup yields an unreadable relative path.

## Related Issue

None.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format-check`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation/template if needed
- [x] My commit messages follow conventional commits format

## Verification

- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/init_command_spec.lua"`
- `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/camouflage/project_config_spec.lua"`
- `rg -n "Available parsers|file_pattern: \\['\\*\\.tf'|Dockerfile|Containerfile|parser: hcl|parser: dockerfile|xml:|hcl:|dockerfile:" lua/camouflage/templates/project_config.yaml`
- `rg -n "hcl|dockerfile|Dockerfile|Containerfile" README.md doc/camouflage.txt lua/camouflage/config.lua schemas/camouflage-project-config.schema.json lua/camouflage/templates/project_config.yaml`
- `make test`
- `make lint`
- `make format-check`
- `git diff --check`

## Screenshots

Not applicable.
