### PR TITLE
fix(json): preserve fallback paths for duplicate values

### DIFF
--- a/lua/camouflage/parsers/json.lua
+++ b/lua/camouflage/parsers/json.lua
@@ -4,9 +4,6 @@ local M = {}
 
 local config = require('camouflage.config')
 
--- Compatibility: vim.islist was added in Neovim 0.10, use vim.tbl_islist for 0.9.x
-local islist = vim.islist or vim.tbl_islist
-
 ---@param content string
 ---@param bufnr number|nil Buffer number for TreeSitter parsing
 ---@return ParsedVariable[]
@@ -30,14 +27,9 @@ function M.parse_regex(content)
   local variables = {}
   local max_depth = config.get().parsers.json.max_depth or 10
 
-  local ok, parsed = pcall(vim.json.decode, content)
-  if ok and parsed then
-    -- Index every key occurrence by document position up front, then consume
-    -- one occurrence per decoded (key, value). This is order-independent: the
-    -- decode walk (pairs()) drives nesting/typing, but positions come from the
-    -- document, so duplicate key names in different objects can never collide.
-    local occurrences = M.collect_key_occurrences(content)
-    M.extract_variables(parsed, content, '', 0, max_depth, variables, occurrences)
+  local ok = pcall(vim.json.decode, content)
+  if ok then
+    M.scan_valid_json(content, max_depth, variables)
   else
     M.parse_with_pattern(content, variables)
   end
@@ -45,152 +37,326 @@ function M.parse_regex(content)
   return variables
 end
 
----Collect every object-key occurrence in document order, escape-aware.
----A string token "..." is a key iff the next non-whitespace char after its
----closing quote is ':'. Returns a map of short-key -> ascending list of
----{ qs = opening-quote pos, qe = closing-quote pos } (1-based).
+---Scan valid JSON in document order and emit supported object scalar values.
+---Arrays and nulls are intentionally skipped to preserve the fallback contract.
 ---@param content string
----@return table<string, table[]>
-function M.collect_key_occurrences(content)
-  local occurrences = {}
-  local pos = 1
-  local len = #content
+---@param variables ParsedVariable[]
+---@return nil
+function M.scan_valid_json(content, max_depth, variables)
+  local pos = M.skip_whitespace(content, 1)
+  local char = content:sub(pos, pos)
 
-  while pos <= len do
-    local qs = content:find('"', pos)
-    if not qs then
-      break
-    end
-    local qe = M.find_closing_quote(content, qs + 1)
-    if not qe then
-      break
-    end
-
-    local after = content:find('%S', qe + 1)
-    if after and content:sub(after, after) == ':' then
-      local raw_key = content:sub(qs + 1, qe - 1)
-      local key = raw_key:gsub('\\"', '"'):gsub('\\\\', '\\')
-      local list = occurrences[key]
-      if not list then
-        list = {}
-        occurrences[key] = list
-      end
-      list[#list + 1] = { qs = qs, qe = qe }
-      pos = after + 1
-    else
-      -- A value string (or any non-key string): skip past its closing quote.
-      pos = qe + 1
-    end
+  if char == '{' then
+    M.scan_object(content, pos, {}, max_depth, variables)
+  elseif char == '[' then
+    M.skip_json_value(content, pos)
   end
-
-  return occurrences
 end
 
----@param obj any
 ---@param content string
----@param key_prefix string
----@param depth number
----@param max_depth number
+---@param pos number
+---@return number
+function M.skip_whitespace(content, pos)
+  local next_pos = content:find('%S', pos)
+  return next_pos or (#content + 1)
+end
+
+---@param raw string
+---@return string
+function M.decode_json_string(raw)
+  local ok, decoded = pcall(vim.json.decode, '"' .. raw .. '"')
+  if ok and type(decoded) == 'string' then
+    return decoded
+  end
+  return raw:gsub('\\"', '"'):gsub('\\\\', '\\')
+end
+
+---@param content string
+---@param quote_pos number
+---@return string|nil raw
+---@return number|nil closing_quote
+function M.parse_string_token(content, quote_pos)
+  if content:sub(quote_pos, quote_pos) ~= '"' then
+    return nil, nil
+  end
+  local closing_quote = M.find_closing_quote(content, quote_pos + 1)
+  if not closing_quote then
+    return nil, nil
+  end
+  return content:sub(quote_pos + 1, closing_quote - 1), closing_quote
+end
+
+---@param path string[]
+---@param key string
+---@return string[]
+function M.path_with_key(path, key)
+  local next_path = {}
+  for i, part in ipairs(path) do
+    next_path[i] = part
+  end
+  next_path[#next_path + 1] = key
+  return next_path
+end
+
+---@param path string[]
+---@param key string
+---@return string
+function M.full_key(path, key)
+  if #path == 0 then
+    return key
+  end
+
+  local parts = M.path_with_key(path, key)
+  return table.concat(parts, '.')
+end
+
+---@param content string
 ---@param variables ParsedVariable[]
----@param occurrences table<string, table[]> Document-order key positions
-function M.extract_variables(obj, content, key_prefix, depth, max_depth, variables, occurrences)
-  if depth > max_depth or type(obj) ~= 'table' then
+---@param path string[]
+---@param key string|nil
+---@param value string
+---@param start_index number
+---@param end_index number
+---@param value_pos number 1-based value start for line number calculation
+---@param max_depth number
+---@return nil
+function M.add_scalar_variable(
+  content,
+  variables,
+  path,
+  key,
+  value,
+  start_index,
+  end_index,
+  value_pos,
+  max_depth
+)
+  if not key or #path > max_depth then
+    return
+  end
+  if value == '' or value:match('^%s*$') then
     return
   end
 
-  for key, value in pairs(obj) do
-    local full_key = key_prefix == '' and key or (key_prefix .. '.' .. key)
-    local value_type = type(value)
-
-    if value_type == 'string' or value_type == 'number' or value_type == 'boolean' then
-      -- Skip empty or whitespace-only string values
-      local should_skip = value_type == 'string' and (value == '' or value:match('^%s*$'))
-      if not should_skip then
-        local list = occurrences[key]
-        if list then
-          for _, occ in ipairs(list) do
-            if not occ.consumed then
-              local position = M.value_at_occurrence(content, occ, value, value_type)
-              if position then
-                occ.consumed = true
-                table.insert(variables, {
-                  key = full_key,
-                  value = tostring(value),
-                  start_index = position.start_index,
-                  end_index = position.end_index,
-                  line_number = position.line_number,
-                  is_nested = depth > 0,
-                  is_commented = false,
-                })
-                break
-              end
-            end
-          end
-        end
-      end
-    elseif value_type == 'table' and not islist(value) then
-      M.extract_variables(value, content, full_key, depth + 1, max_depth, variables, occurrences)
-    end
-  end
+  table.insert(variables, {
+    key = M.full_key(path, key),
+    value = value,
+    start_index = start_index,
+    end_index = end_index,
+    line_number = M.get_line_number(content, value_pos),
+    is_nested = #path > 0,
+    is_commented = false,
+  })
 end
 
----Resolve the scalar value position for a key occurrence, if the value there
----matches the expected decoded value. Structural and position-anchored: it
----reads the ':' and value immediately after the key occurrence, never searching
----forward, so it cannot drift onto another object's identically-named key.
 ---@param content string
----@param occ table { qs, qe } occurrence (1-based quote positions)
----@param value any Decoded value
----@param value_type string 'string'|'number'|'boolean'
----@return {start_index: number, end_index: number, line_number: number}|nil
-function M.value_at_occurrence(content, occ, value, value_type)
-  -- Only whitespace may sit between the key's closing quote and the ':'.
-  local _, colon_end = content:find('^%s*:', occ.qe + 1)
-  if not colon_end then
-    return nil
-  end
-  local value_start = content:find('%S', colon_end + 1)
-  if not value_start then
-    return nil
+---@param pos number
+---@param path string[]
+---@param max_depth number
+---@param variables ParsedVariable[]
+---@return number
+function M.scan_object(content, pos, path, max_depth, variables)
+  pos = M.skip_whitespace(content, pos + 1)
+  if content:sub(pos, pos) == '}' then
+    return pos + 1
   end
 
-  if value_type == 'string' then
-    if content:sub(value_start, value_start) ~= '"' then
-      return nil
+  while pos <= #content do
+    local raw_key, key_end = M.parse_string_token(content, pos)
+    if not raw_key or not key_end then
+      return pos + 1
     end
-    local value_content_start = value_start + 1
-    local value_end = M.find_closing_quote(content, value_content_start)
-    if not value_end then
-      return nil
+
+    local key = M.decode_json_string(raw_key)
+    pos = M.skip_whitespace(content, key_end + 1)
+    if content:sub(pos, pos) ~= ':' then
+      return pos + 1
     end
-    -- Verify the raw value matches the decoded value when unescaped
-    local raw_value = content:sub(value_content_start, value_end - 1)
-    local unescaped = raw_value:gsub('\\"', '"'):gsub('\\\\', '\\')
-    if unescaped ~= value then
-      return nil
+
+    pos = M.scan_value(content, pos + 1, path, key, max_depth, variables)
+    pos = M.skip_whitespace(content, pos)
+
+    local char = content:sub(pos, pos)
+    if char == ',' then
+      pos = M.skip_whitespace(content, pos + 1)
+    elseif char == '}' then
+      return pos + 1
+    else
+      return pos + 1
     end
-    return {
-      start_index = value_content_start - 1,
-      end_index = value_end - 1,
-      line_number = M.get_line_number(content, value_content_start),
-    }
-  else
-    local str_value = tostring(value)
-    if content:sub(value_start, value_start + #str_value - 1) ~= str_value then
-      return nil
-    end
-    -- The literal must end at a JSON delimiter so value 1 does not match the
-    -- leading '1' of 12.
-    local after = content:sub(value_start + #str_value, value_start + #str_value)
-    if after ~= '' and not after:match('[%s,%]}]') then
-      return nil
-    end
-    return {
-      start_index = value_start - 1,
-      end_index = value_start + #str_value - 1,
-      line_number = M.get_line_number(content, value_start),
-    }
   end
+
+  return pos
+end
+
+---@param content string
+---@param pos number
+---@param path string[]
+---@param key string|nil
+---@param max_depth number
+---@param variables ParsedVariable[]
+---@return number
+function M.scan_value(content, pos, path, key, max_depth, variables)
+  pos = M.skip_whitespace(content, pos)
+  local char = content:sub(pos, pos)
+
+  if char == '{' then
+    local child_path = key and M.path_with_key(path, key) or path
+    return M.scan_object(content, pos, child_path, max_depth, variables)
+  elseif char == '[' then
+    return M.skip_json_value(content, pos)
+  elseif char == '"' then
+    local raw_value, value_end = M.parse_string_token(content, pos)
+    if not raw_value or not value_end then
+      return pos + 1
+    end
+    M.add_scalar_variable(
+      content,
+      variables,
+      path,
+      key,
+      raw_value,
+      pos,
+      value_end - 1,
+      pos + 1,
+      max_depth
+    )
+    return value_end + 1
+  elseif content:sub(pos, pos + 3) == 'true' then
+    M.add_scalar_variable(content, variables, path, key, 'true', pos - 1, pos + 3, pos, max_depth)
+    return pos + 4
+  elseif content:sub(pos, pos + 4) == 'false' then
+    M.add_scalar_variable(content, variables, path, key, 'false', pos - 1, pos + 4, pos, max_depth)
+    return pos + 5
+  elseif content:sub(pos, pos + 3) == 'null' then
+    return pos + 4
+  end
+
+  local raw_number, number_end = M.parse_number_literal(content, pos)
+  if raw_number and number_end then
+    M.add_scalar_variable(
+      content,
+      variables,
+      path,
+      key,
+      raw_number,
+      pos - 1,
+      number_end,
+      pos,
+      max_depth
+    )
+    return number_end + 1
+  end
+
+  return pos + 1
+end
+
+---@param content string
+---@param pos number
+---@return string|nil raw_number
+---@return number|nil end_pos
+function M.parse_number_literal(content, pos)
+  local len = #content
+  local start_pos = pos
+
+  if content:sub(pos, pos) == '-' then
+    pos = pos + 1
+  end
+
+  local char = content:sub(pos, pos)
+  if char == '0' then
+    pos = pos + 1
+  elseif char:match('[1-9]') then
+    repeat
+      pos = pos + 1
+      char = content:sub(pos, pos)
+    until pos > len or not char:match('%d')
+  else
+    return nil, nil
+  end
+
+  if content:sub(pos, pos) == '.' then
+    pos = pos + 1
+    if not content:sub(pos, pos):match('%d') then
+      return nil, nil
+    end
+    repeat
+      pos = pos + 1
+      char = content:sub(pos, pos)
+    until pos > len or not char:match('%d')
+  end
+
+  char = content:sub(pos, pos)
+  if char == 'e' or char == 'E' then
+    pos = pos + 1
+    char = content:sub(pos, pos)
+    if char == '+' or char == '-' then
+      pos = pos + 1
+    end
+    if not content:sub(pos, pos):match('%d') then
+      return nil, nil
+    end
+    repeat
+      pos = pos + 1
+      char = content:sub(pos, pos)
+    until pos > len or not char:match('%d')
+  end
+
+  return content:sub(start_pos, pos - 1), pos - 1
+end
+
+---@param content string
+---@param pos number
+---@return number
+function M.skip_json_value(content, pos)
+  pos = M.skip_whitespace(content, pos)
+  local char = content:sub(pos, pos)
+
+  if char == '"' then
+    local _, closing_quote = M.parse_string_token(content, pos)
+    return closing_quote and (closing_quote + 1) or (#content + 1)
+  elseif char == '{' then
+    return M.skip_balanced(content, pos, '{', '}')
+  elseif char == '[' then
+    return M.skip_balanced(content, pos, '[', ']')
+  elseif content:sub(pos, pos + 3) == 'true' or content:sub(pos, pos + 3) == 'null' then
+    return pos + 4
+  elseif content:sub(pos, pos + 4) == 'false' then
+    return pos + 5
+  end
+
+  local _, number_end = M.parse_number_literal(content, pos)
+  return number_end and (number_end + 1) or (pos + 1)
+end
+
+---@param content string
+---@param pos number
+---@param open_char string
+---@param close_char string
+---@return number
+function M.skip_balanced(content, pos, open_char, close_char)
+  local depth = 0
+
+  while pos <= #content do
+    local char = content:sub(pos, pos)
+    if char == '"' then
+      local _, closing_quote = M.parse_string_token(content, pos)
+      pos = closing_quote and (closing_quote + 1) or (#content + 1)
+    elseif char == open_char then
+      depth = depth + 1
+      pos = pos + 1
+    elseif char == close_char then
+      depth = depth - 1
+      pos = pos + 1
+      if depth == 0 then
+        return pos
+      end
+    else
+      pos = pos + 1
+    end
+  end
+
+  return pos
 end
 
 ---Find the closing quote, handling escaped quotes

--- a/tests/camouflage/parsers/json_spec.lua
+++ b/tests/camouflage/parsers/json_spec.lua
@@ -105,6 +105,18 @@ describe('camouflage.parsers.json', function()
       assert.equals('password', result[1].key)
     end)
 
+    it('should skip objects inside arrays', function()
+      local content = [[{
+  "items": [{ "password": "array_secret" }],
+  "password": "secret"
+}]]
+      local result = json_parser.parse(content)
+
+      assert.equals(1, #result)
+      assert.equals('password', result[1].key)
+      assert.equals('secret', result[1].value)
+    end)
+
     it('should handle empty objects', function()
       local content = '{}'
       local result = json_parser.parse(content)
@@ -168,12 +180,38 @@ describe('camouflage.parsers.json', function()
       assert.equals(0, #result)
     end)
 
+    it('should use the pattern fallback for invalid JSON with string pairs', function()
+      local result = json_parser.parse('{"api_key": "secret", invalid')
+
+      assert.equals(1, #result)
+      assert.equals('api_key', result[1].key)
+      assert.equals('secret', result[1].value)
+    end)
+
     it('should handle unicode values', function()
       local result = json_parser.parse('{"greeting": "Hello 世界"}')
 
       assert.equals(1, #result)
       assert.equals('greeting', result[1].key)
       assert.equals('Hello 世界', result[1].value)
+    end)
+
+    it('should handle escaped quotes inside string values', function()
+      local content = '{"token":"a\\"b","password":"secret"}'
+      local result = json_parser.parse(content)
+
+      local values = {}
+      for _, v in ipairs(result) do
+        values[v.key] = v
+      end
+
+      assert.equals(2, #result)
+      assert.equals('a\\"b', values.token.value)
+      assert.equals(
+        values.token.value,
+        content:sub(values.token.start_index + 1, values.token.end_index)
+      )
+      assert.equals('secret', values.password.value)
     end)
 
     it('should handle whitespace-only values', function()
@@ -200,6 +238,49 @@ describe('camouflage.parsers.json', function()
       assert.is_true(seen['AAA'])
       assert.is_true(seen['BBB'])
       assert.is_true(seen['CCC'])
+    end)
+
+    it('should keep duplicate nested identical values on their own key paths', function()
+      local cases = {
+        { first = 'a', second = 'b' },
+        { first = 'ab', second = 'aa' },
+      }
+
+      for _, case in ipairs(cases) do
+        local content = string.format(
+          '{"%s":{"password":"same"},"%s":{"password":"same"}}',
+          case.first,
+          case.second
+        )
+        local result = json_parser.parse(content)
+
+        local first_open =
+          content:find('"same"', content:find('"' .. case.first .. '"', 1, true), true)
+        local second_open =
+          content:find('"same"', content:find('"' .. case.second .. '"', 1, true), true)
+        local expected = {
+          [case.first .. '.password'] = {
+            start_index = first_open,
+            end_index = first_open + #'same',
+            value = 'same',
+          },
+          [case.second .. '.password'] = {
+            start_index = second_open,
+            end_index = second_open + #'same',
+            value = 'same',
+          },
+        }
+
+        assert.equals(2, #result)
+        for _, var in ipairs(result) do
+          local expected_var = expected[var.key]
+          assert.is_not_nil(expected_var, 'unexpected key: ' .. var.key)
+          assert.equals(expected_var.value, var.value)
+          assert.equals(expected_var.start_index, var.start_index, var.key)
+          assert.equals(expected_var.end_index, var.end_index, var.key)
+          assert.equals(var.value, content:sub(var.start_index + 1, var.end_index))
+        end
+      end
     end)
 
     it('should position values on their own bytes (offset contract)', function()

--- a/tests/camouflage/parsers/offsets_contract_spec.lua
+++ b/tests/camouflage/parsers/offsets_contract_spec.lua
@@ -31,6 +31,12 @@ describe('camouflage parsers offset contract', function()
       expect_count = 3,
     },
     {
+      name = 'json duplicate identical values across objects',
+      parser = 'camouflage.parsers.json',
+      content = '{"ab":{"password":"same"},"aa":{"password":"same"}}',
+      expect_count = 2,
+    },
+    {
       name = 'yaml',
       parser = 'camouflage.parsers.yaml',
       content = 'api_key: secret123\ndb:\n  password: hunter2\n',


### PR DESCRIPTION
## Description

Fixes JSON regex fallback path attribution when duplicate nested objects reuse the same short key and scalar value.

For valid JSON fallback parsing, the parser now scans the source object structure in document order, maintains the current key path, and emits supported scalar positions directly from the syntax it just read. Invalid JSON still uses the existing pattern fallback.

## Root Cause

The previous fallback decoded JSON into Lua tables, walked objects with `pairs()`, and then matched document positions by short key name and scalar value. Since `pairs()` order is not document order, identical nested values could bind the wrong full key path to a value position.

Example risk:

```json
{"a":{"password":"same"},"b":{"password":"same"}}
```

The value slices could still be valid while `a.password` and `b.password` were associated with the wrong occurrences.

## Behavior

- Preserves path-accurate output for duplicate nested keys with identical scalar values.
- Keeps arrays and `null` skipped in the JSON fallback path.
- Keeps invalid JSON degradation through the existing pattern fallback.
- Preserves 0-based, end-exclusive parser offsets.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Validation

- [x] Added regression coverage for duplicate nested identical JSON values.
- [x] Added coverage for skipped objects inside arrays, escaped quote string scanning, invalid JSON pattern fallback, and duplicate identical value offsets.
- [x] `make test`
- [x] `make lint`
- [x] `make format-check`
- [x] `git diff --check`
