### PR TITLE
fix(position): honor end-exclusive cursor bounds

### DIFF
--- a/lua/camouflage/position.lua
+++ b/lua/camouflage/position.lua
@@ -129,7 +129,7 @@ function M.find_variable_at_cursor(bufnr, variables, opts)
 
   -- First pass: exact match (cursor within value byte range)
   for _, var in ipairs(variables) do
-    if cursor_byte >= var.start_index and cursor_byte <= var.end_index then
+    if cursor_byte >= var.start_index and cursor_byte < var.end_index then
       return var
     end
   end
@@ -145,8 +145,8 @@ function M.find_variable_at_cursor(bufnr, variables, opts)
         local dist
         if cursor_byte < var.start_index then
           dist = var.start_index - cursor_byte
-        elseif cursor_byte > var.end_index then
-          dist = cursor_byte - var.end_index
+        elseif cursor_byte >= var.end_index then
+          dist = cursor_byte - (var.end_index - 1)
         else
           dist = 0
         end

--- a/tests/camouflage/position_spec.lua
+++ b/tests/camouflage/position_spec.lua
@@ -29,6 +29,42 @@ describe('camouflage.position', function()
   end)
 
   describe('find_variable_at_cursor', function()
+    it('strict mode matches the first byte of an end-exclusive value range', function()
+      local bufnr = setup_buf({ 'API_KEY=secret123' })
+      local vars = {
+        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 17, line_number = 0 },
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 8 }) -- first byte of the value
+
+      local var = position.find_variable_at_cursor(bufnr, vars, { same_line_fallback = false })
+
+      assert.equals('API_KEY', var.key)
+    end)
+
+    it('strict mode matches the last byte before an end-exclusive boundary', function()
+      local bufnr = setup_buf({ 'API_KEY=secret123' })
+      local vars = {
+        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 17, line_number = 0 },
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 16 }) -- last byte of the value
+
+      local var = position.find_variable_at_cursor(bufnr, vars, { same_line_fallback = false })
+
+      assert.equals('API_KEY', var.key)
+    end)
+
+    it('strict mode does not match at the end-exclusive boundary', function()
+      local bufnr = setup_buf({ 'API_KEY=secret123,' })
+      local vars = {
+        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 17, line_number = 0 },
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 17 }) -- comma after the value
+
+      local var = position.find_variable_at_cursor(bufnr, vars, { same_line_fallback = false })
+
+      assert.is_nil(var)
+    end)
+
     it('returns the variable whose byte range contains the cursor', function()
       local bufnr = setup_buf({ 'API_KEY=secret123' })
       local vars = {
@@ -57,6 +93,18 @@ describe('camouflage.position', function()
       vim.api.nvim_win_set_cursor(0, { 1, 7 }) -- between values, closer to BBB
       local var = position.find_variable_at_cursor(bufnr, vars, { same_line_fallback = true })
       assert.equals('b', var.key)
+    end)
+
+    it('lenient fallback still selects the nearest variable at an end boundary', function()
+      local bufnr = setup_buf({ 'API_KEY=secret123,' })
+      local vars = {
+        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 17, line_number = 0 },
+      }
+      vim.api.nvim_win_set_cursor(0, { 1, 17 }) -- comma after the value
+
+      local var = position.find_variable_at_cursor(bufnr, vars, { same_line_fallback = true })
+
+      assert.equals('API_KEY', var.key)
     end)
   end)
 end)

--- a/tests/camouflage/pwned/init_spec.lua
+++ b/tests/camouflage/pwned/init_spec.lua
@@ -10,6 +10,7 @@ end
 
 describe('camouflage.pwned', function()
   local pwned
+  local test_counter = 0
 
   local function with_system_unavailable(fn)
     local original_system = vim.system
@@ -24,6 +25,15 @@ describe('camouflage.pwned', function()
   before_each(function()
     pwned = require('camouflage.pwned')
   end)
+
+  local function setup_test_buffer(content, filename)
+    test_counter = test_counter + 1
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(content, '\n'))
+    vim.api.nvim_buf_set_name(bufnr, (filename or '/tmp/pwned.env') .. '.' .. test_counter)
+    vim.api.nvim_set_current_buf(bufnr)
+    return bufnr
+  end
 
   describe('setup', function()
     it('should not error', function()
@@ -91,6 +101,49 @@ describe('camouflage.pwned', function()
       cache.set('TEST', { pwned = true, count = 1 })
       pwned.clear_cache()
       assert.is_nil(cache.get('TEST'))
+    end)
+  end)
+
+  describe('check_current', function()
+    it('does not check a variable when the cursor is at its end-exclusive boundary', function()
+      local pwned_check = require('camouflage.pwned.check')
+      local state = require('camouflage.state')
+      local original_is_available = pwned_check.is_available
+      local original_check_variable = pwned_check.check_variable
+      local original_notify = vim.notify
+
+      local ok, err = pcall(function()
+        local bufnr = setup_test_buffer('PASSWORD=secret,', '/tmp/pwned.env')
+        state.set_variables(bufnr, {
+          { key = 'PASSWORD', value = 'secret', start_index = 9, end_index = 15, line_number = 0 },
+        })
+        vim.api.nvim_win_set_cursor(0, { 1, 15 }) -- comma after the value
+
+        local checked = false
+        pwned_check.is_available = function()
+          return true
+        end
+        pwned_check.check_variable = function()
+          checked = true
+        end
+        vim.notify = function() end
+
+        local callback_result = 'unset'
+        pwned.check_current(function(result)
+          callback_result = result
+        end)
+
+        assert.is_false(checked)
+        assert.is_nil(callback_result)
+      end)
+
+      pwned_check.is_available = original_is_available
+      pwned_check.check_variable = original_check_variable
+      vim.notify = original_notify
+
+      if not ok then
+        error(err, 0)
+      end
     end)
   end)
 

--- a/tests/camouflage/yank_spec.lua
+++ b/tests/camouflage/yank_spec.lua
@@ -55,8 +55,8 @@ describe('camouflage.yank', function()
       local bufnr = setup_test_buffer('API_KEY=secret123\nDEBUG=true', '/tmp/test.env')
       -- Set variables manually for testing
       state.set_variables(bufnr, {
-        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 16 },
-        { key = 'DEBUG', value = 'true', start_index = 24, end_index = 27 },
+        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 17 },
+        { key = 'DEBUG', value = 'true', start_index = 24, end_index = 28 },
       })
       -- Position cursor on an empty line (if we had one)
       vim.api.nvim_win_set_cursor(0, { 1, 0 }) -- At 'A' of API_KEY
@@ -68,7 +68,7 @@ describe('camouflage.yank', function()
     it('returns variable when cursor is on masked value', function()
       local bufnr = setup_test_buffer('API_KEY=secret123', '/tmp/test.env')
       state.set_variables(bufnr, {
-        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 16 },
+        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 17 },
       })
       vim.api.nvim_win_set_cursor(0, { 1, 10 }) -- On 'secret123'
       local result = yank.find_variable_at_cursor()
@@ -79,10 +79,23 @@ describe('camouflage.yank', function()
     it('returns variable when cursor is on same line', function()
       local bufnr = setup_test_buffer('API_KEY=secret123', '/tmp/test.env')
       state.set_variables(bufnr, {
-        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 16 },
+        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 17 },
       })
       vim.api.nvim_win_set_cursor(0, { 1, 0 }) -- At beginning of line
       local result = yank.find_variable_at_cursor()
+      assert.is_not_nil(result)
+      assert.equals('API_KEY', result.key)
+    end)
+
+    it('returns nearest same-line variable when cursor is just after the value', function()
+      local bufnr = setup_test_buffer('API_KEY=secret123,', '/tmp/test.env')
+      state.set_variables(bufnr, {
+        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 17 },
+      })
+      vim.api.nvim_win_set_cursor(0, { 1, 17 }) -- comma after the value
+
+      local result = yank.find_variable_at_cursor()
+
       assert.is_not_nil(result)
       assert.equals('API_KEY', result.key)
     end)
@@ -123,7 +136,7 @@ describe('camouflage.yank', function()
     it('uses cursor when on variable', function()
       local bufnr = setup_test_buffer('API_KEY=secret123', '/tmp/test.env')
       state.set_variables(bufnr, {
-        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 16 },
+        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 17 },
       })
       vim.api.nvim_win_set_cursor(0, { 1, 10 })
 
@@ -146,7 +159,7 @@ describe('camouflage.yank', function()
     it('shows picker when not on variable line', function()
       local bufnr = setup_test_buffer('# Comment\nAPI_KEY=secret123', '/tmp/test.env')
       state.set_variables(bufnr, {
-        { key = 'API_KEY', value = 'secret123', start_index = 18, end_index = 26 },
+        { key = 'API_KEY', value = 'secret123', start_index = 18, end_index = 27 },
       })
       vim.api.nvim_win_set_cursor(0, { 1, 0 }) -- On comment line
 
@@ -168,7 +181,7 @@ describe('camouflage.yank', function()
     it('forces picker with force_picker option', function()
       local bufnr = setup_test_buffer('API_KEY=secret123', '/tmp/test.env')
       state.set_variables(bufnr, {
-        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 16 },
+        { key = 'API_KEY', value = 'secret123', start_index = 8, end_index = 17 },
       })
       vim.api.nvim_win_set_cursor(0, { 1, 10 }) -- On the value
 
@@ -210,9 +223,9 @@ describe('camouflage.yank', function()
     it('shows all variables in picker', function()
       local bufnr = setup_test_buffer('A=1\nB=2\nC=3', '/tmp/test.env')
       state.set_variables(bufnr, {
-        { key = 'A', value = '1', start_index = 2, end_index = 2 },
-        { key = 'B', value = '2', start_index = 6, end_index = 6 },
-        { key = 'C', value = '3', start_index = 10, end_index = 10 },
+        { key = 'A', value = '1', start_index = 2, end_index = 3 },
+        { key = 'B', value = '2', start_index = 6, end_index = 7 },
+        { key = 'C', value = '3', start_index = 10, end_index = 11 },
       })
 
       local picker_items = nil
@@ -235,7 +248,7 @@ describe('camouflage.yank', function()
     it('does not show values in picker items', function()
       local bufnr = setup_test_buffer('SECRET=mysecretvalue', '/tmp/test.env')
       state.set_variables(bufnr, {
-        { key = 'SECRET', value = 'mysecretvalue', start_index = 7, end_index = 19 },
+        { key = 'SECRET', value = 'mysecretvalue', start_index = 7, end_index = 20 },
       })
 
       local formatted_item = nil
@@ -257,7 +270,7 @@ describe('camouflage.yank', function()
     it('handles user cancellation', function()
       local bufnr = setup_test_buffer('A=1', '/tmp/test.env')
       state.set_variables(bufnr, {
-        { key = 'A', value = '1', start_index = 2, end_index = 2 },
+        { key = 'A', value = '1', start_index = 2, end_index = 3 },
       })
 
       local original_select = vim.ui.select
@@ -291,7 +304,7 @@ describe('camouflage.yank', function()
 
       local bufnr = setup_test_buffer('A=1', '/tmp/test.env')
       state.set_variables(bufnr, {
-        { key = 'A', value = '1', start_index = 2, end_index = 2 },
+        { key = 'A', value = '1', start_index = 2, end_index = 3 },
       })
 
       local confirm_shown = false
@@ -328,7 +341,7 @@ describe('camouflage.yank', function()
 
       local bufnr = setup_test_buffer('A=secret', '/tmp/test.env')
       state.set_variables(bufnr, {
-        { key = 'A', value = 'secret', start_index = 2, end_index = 7 },
+        { key = 'A', value = 'secret', start_index = 2, end_index = 8 },
       })
 
       local original_select = vim.ui.select


### PR DESCRIPTION
## Description

Fixes cursor matching at parser `end_index` boundaries so strict cursor lookups honor the documented end-exclusive offset contract.

`position.find_variable_at_cursor()` now treats value ranges as `[start_index, end_index)`. A cursor on the delimiter immediately after a value no longer counts as being on that secret in strict mode.

## Root Cause

Parsers emit 0-based, end-exclusive byte offsets, but the shared cursor helper used an inclusive upper bound:

```lua
cursor_byte <= var.end_index
```

That let strict callers select a secret when the cursor byte was exactly equal to `end_index`, which is the first byte after the value. This matters for pwned checks because strict cursor selection can initiate a HIBP check for the selected value.

## Behavior

- Strict cursor matching still selects the first byte of a value.
- Strict cursor matching still selects the last byte before `end_index`.
- Strict cursor matching no longer selects at `cursor_byte == end_index`.
- Yank keeps its same-line fallback behavior and still selects the nearest same-line variable when outside exact value ranges.
- `pwned.check_current()` does not check a variable when the cursor is immediately after the value.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Validation

- [x] Added strict boundary tests for start byte, last value byte, and exact end-exclusive boundary.
- [x] Added yank same-line fallback boundary coverage.
- [x] Added pwned `check_current()` coverage proving no check is triggered at the end boundary.
- [x] `make test`
- [x] `make lint`
- [x] `make format-check`
- [x] `git diff --check`
