### PR TITLE
fix: handle multiline masking and parser ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,21 @@ With `debug = true`, custom check logs include check names, run counts, failures
 | Dockerfile | `Dockerfile`, `Containerfile`, `*.dockerfile` | No |
 
 For unsupported formats, you can define [custom patterns](https://github.com/zeybek/camouflage.nvim/wiki/Custom-Patterns).
+These are opt-in; a fixture such as `test.myconfig` will not be masked until you map that filename pattern:
+
+```lua
+require('camouflage').setup({
+  custom_patterns = {
+    {
+      file_pattern = { '*.myconfig' },
+      pattern = '^%s*@([%w_]+)%s*=%s*(.+)',
+      key_capture = 1,
+      value_capture = 2,
+    },
+  },
+})
+```
+
 Runtime parser registrations with `file_patterns` are picked up by automatic masking immediately after registration.
 
 When TreeSitter is available, JSON/YAML/XML nested keys are reported with their full path. XML attributes use `parent.path@attribute` so attributes and child elements with the same name stay distinct.

--- a/doc/camouflage.txt
+++ b/doc/camouflage.txt
@@ -1038,7 +1038,7 @@ patterns using Lua patterns:
     custom_patterns = {
       {
         file_pattern = { '*.myconfig' },  -- Glob pattern(s) for file matching
-        pattern = '@([%w_]+)%s*=%s*(.+)', -- Lua pattern with capture groups
+        pattern = '^%s*@([%w_]+)%s*=%s*(.+)', -- Lua pattern with capture groups
         key_capture = 1,                   -- Capture group for key (optional)
         value_capture = 2,                 -- Capture group for value (required)
       },
@@ -1074,7 +1074,7 @@ value_capture ~
 Example patterns:
 >lua
   -- @variable = value
-  { pattern = '@([%w_]+)%s*=%s*(.+)', key_capture = 1, value_capture = 2 }
+  { pattern = '^%s*@([%w_]+)%s*=%s*(.+)', key_capture = 1, value_capture = 2 }
 
   -- SECRET: value
   { pattern = 'SECRET:%s*(.+)', value_capture = 1 }
@@ -1088,6 +1088,8 @@ Example patterns:
 
 Note: Built-in parsers take priority over custom patterns. If a file matches
 a built-in parser (e.g., `.json`, `.env`), the custom pattern will not be used.
+Custom patterns are opt-in for unsupported filenames; for example, `*.myconfig`
+files are ignored until a matching `custom_patterns` entry is configured.
 
 ==============================================================================
 STYLES                                                      *camouflage-styles*

--- a/lua/camouflage/parsers/xml.lua
+++ b/lua/camouflage/parsers/xml.lua
@@ -70,8 +70,14 @@ function M.parse_elements(content, variables, max_depth)
       tag_pattern
     )
 
-    -- Track opening tags that span multiple lines (no closing tag on same line)
-    for tag_name in processing_line:gmatch('<(' .. tag_pattern .. ')[^/>]*>') do
+    -- Track opening tags that span multiple lines (no closing tag on same line).
+    -- Attributes may contain "/" (for example namespace URLs), so inspect the
+    -- tag tail instead of excluding "/" from the whole match.
+    for tag_name, tag_tail in processing_line:gmatch('<(' .. tag_pattern .. ')([^>]*)>') do
+      if tag_tail:match('/%s*$') then
+        goto continue_open_tag
+      end
+
       -- Check if this tag has a closing tag on the same line
       local has_close_on_line = processing_line:match('</' .. M.escape_pattern(tag_name) .. '%s*>')
       if not has_close_on_line then
@@ -79,6 +85,8 @@ function M.parse_elements(content, variables, max_depth)
           table.insert(tag_stack, tag_name)
         end
       end
+
+      ::continue_open_tag::
     end
 
     -- Track closing tags that close multi-line elements
@@ -208,6 +216,76 @@ local function find_attribute(content, from)
   return nil
 end
 
+---@param content string
+---@param pos number
+---@return number|nil
+local function find_tag_start_before(content, pos)
+  local tag_start = nil
+  local search_pos = 1
+  while true do
+    local found = content:find('<', search_pos, true)
+    if not found or found >= pos then
+      break
+    end
+    tag_start = found
+    search_pos = found + 1
+  end
+  return tag_start
+end
+
+---@param content string
+---@param limit number
+---@return string[]
+function M.get_element_stack_before(content, limit)
+  local stack = {}
+  local tag_pattern = '[%w_%-:.]+'
+  local pos = 1
+
+  while pos < limit do
+    local tag_start, tag_end, closing, tag_name, tag_tail =
+      content:find('<%s*(/?)(' .. tag_pattern .. ')([^>]*)>', pos)
+    if not tag_start or tag_start >= limit then
+      break
+    end
+
+    if closing == '/' then
+      for i = #stack, 1, -1 do
+        if stack[i] == tag_name then
+          table.remove(stack, i)
+          break
+        end
+      end
+    elseif not tag_tail:match('/%s*$') then
+      table.insert(stack, tag_name)
+    end
+
+    pos = tag_end + 1
+  end
+
+  return stack
+end
+
+---@param content string
+---@param attr_start number
+---@param attr_name string
+---@return string
+function M.get_attribute_key_path(content, attr_start, attr_name)
+  local tag_start = find_tag_start_before(content, attr_start)
+  if not tag_start then
+    return attr_name
+  end
+
+  local tag_pattern = '[%w_%-:.]+'
+  local tag_name = content:match('^<%s*(' .. tag_pattern .. ')', tag_start)
+  if not tag_name then
+    return attr_name
+  end
+
+  local stack = M.get_element_stack_before(content, tag_start)
+  local element_path = M.build_key_path(stack, tag_name)
+  return element_path .. '@' .. attr_name
+end
+
 ---Parse attributes like attr="value" or attr='value'
 ---@param content string
 ---@param variables ParsedVariable[]
@@ -226,14 +304,15 @@ function M.parse_attributes(content, variables)
     if not M.is_in_xml_declaration(content, attr_start) then
       -- Skip empty/whitespace values
       if attr_value and not attr_value:match('^%s*$') then
+        local key = M.get_attribute_key_path(content, attr_start, attr_name)
         local value_end = value_pos + #attr_value
         table.insert(variables, {
-          key = attr_name,
+          key = key,
           value = attr_value,
           start_index = value_pos - 1, -- 0-indexed
           end_index = value_end - 1, -- 0-indexed (exclusive)
           line_number = M.get_line_number(content, value_pos),
-          is_nested = false,
+          is_nested = key ~= attr_name,
           is_commented = false,
         })
       end

--- a/lua/camouflage/reveal.lua
+++ b/lua/camouflage/reveal.lua
@@ -20,6 +20,7 @@ local revealed_state = {
   anchor_id = nil, -- extmark id tracking the revealed line through edits
   autocmd_id = nil,
   hook_id = nil, -- variable_detected hook to skip revealed line
+  after_decorate_hook_id = nil, -- after_decorate hook to restore revealed multiline rows
 }
 
 ---Resolve the currently revealed line (1-indexed) from the anchor extmark,
@@ -77,24 +78,55 @@ local function get_reveal_config()
   }, cfg.reveal or {})
 end
 
----Get the line number for a variable
+---Get the visible value range for a variable on a specific line.
+---@param var table
+---@param line_0 number 0-indexed line number
+---@param lines string[]
+---@param line_offsets number[]
+---@return number|nil col_start
+---@return number|nil col_end
+local function var_range_on_line(var, line_0, lines, line_offsets)
+  local line = lines[line_0 + 1]
+  local line_start = line_offsets[line_0 + 1]
+  if not line or not line_start or not var.start_index then
+    return nil, nil
+  end
+
+  local value_end = var.end_index or var.start_index
+  if value_end <= var.start_index then
+    value_end = var.start_index + #(var.value or '')
+  end
+
+  local line_end = line_start + #line
+  local start_index = math.max(var.start_index, line_start)
+  local end_index = math.min(value_end, line_end)
+  if end_index <= start_index then
+    return nil, nil
+  end
+
+  local col_start = start_index - line_start
+  local col_end = end_index - line_start
+  local line_content = line:sub(col_start + 1, col_end)
+  if line_content:match('^%s*$') then
+    return nil, nil
+  end
+
+  return col_start, col_end
+end
+
 ---@param bufnr number
 ---@param var table
----@return number|nil 1-indexed line number
-local function get_var_line(bufnr, var)
-  -- Builtin parsers always set line_number (0-indexed), so this is O(1) with no
-  -- buffer read — important because line_has_variables runs on every cursor move
-  -- in follow mode.
-  if var.line_number then
-    return var.line_number + 1
-  end
+---@param line_0 number 0-indexed line number
+---@return boolean
+local function var_has_value_on_line(bufnr, var, line_0)
   local ok, lines = pcall(vim.api.nvim_buf_get_lines, bufnr, 0, -1, false)
   if not ok then
-    return nil
+    return false
   end
+
   local line_offsets = core.compute_line_offsets(lines)
-  local pos = core.index_to_position(bufnr, var.start_index, lines, line_offsets)
-  return pos and (pos.row + 1) or nil
+  local col_start = var_range_on_line(var, line_0, lines, line_offsets)
+  return col_start ~= nil
 end
 
 ---Check if a line has any masked variables
@@ -103,9 +135,15 @@ end
 ---@return boolean
 local function line_has_variables(bufnr, line)
   local variables = state.get_variables(bufnr)
+  local ok, lines = pcall(vim.api.nvim_buf_get_lines, bufnr, 0, -1, false)
+  if not ok then
+    return false
+  end
+
+  local line_0 = line - 1
+  local line_offsets = core.compute_line_offsets(lines)
   for _, var in ipairs(variables) do
-    local var_line = get_var_line(bufnr, var)
-    if var_line == line then
+    if var_range_on_line(var, line_0, lines, line_offsets) then
       return true
     end
   end
@@ -138,24 +176,21 @@ local function apply_revealed_highlight(bufnr, line)
   local line_offsets = core.compute_line_offsets(lines)
 
   for _, var in ipairs(variables) do
-    local var_pos = core.index_to_position(bufnr, var.start_index, lines, line_offsets)
-    if var_pos and var_pos.row == line then
-      local end_pos = core.index_to_position(bufnr, var.end_index, lines, line_offsets)
-      if end_pos then
-        local extmark_ok, extmark_err =
-          pcall(vim.api.nvim_buf_set_extmark, bufnr, state.namespace, line, var_pos.col, {
-            end_row = end_pos.row,
-            end_col = end_pos.col,
-            hl_group = cfg.highlight_group,
-            priority = 101,
-          })
-        if not extmark_ok then
-          log.pcall_error(
-            'nvim_buf_set_extmark',
-            extmark_err,
-            { bufnr = bufnr, line = line, col = var_pos.col }
-          )
-        end
+    local col_start, col_end = var_range_on_line(var, line, lines, line_offsets)
+    if col_start and col_end then
+      local extmark_ok, extmark_err =
+        pcall(vim.api.nvim_buf_set_extmark, bufnr, state.namespace, line, col_start, {
+          end_row = line,
+          end_col = col_end,
+          hl_group = cfg.highlight_group,
+          priority = 101,
+        })
+      if not extmark_ok then
+        log.pcall_error(
+          'nvim_buf_set_extmark',
+          extmark_err,
+          { bufnr = bufnr, line = line, col = col_start }
+        )
       end
     end
   end
@@ -166,10 +201,22 @@ end
 local function setup_reveal_hook()
   revealed_state.hook_id = hooks.on('variable_detected', function(bufnr, var)
     if revealed_state.bufnr == bufnr then
-      local var_line = get_var_line(bufnr, var)
-      if var_line == current_revealed_line() then
+      local line = current_revealed_line()
+      if line and not var.is_multiline and var_has_value_on_line(bufnr, var, line - 1) then
         return false -- Skip masking this variable
       end
+    end
+  end)
+
+  revealed_state.after_decorate_hook_id = hooks.on('after_decorate', function(bufnr)
+    if revealed_state.bufnr ~= bufnr then
+      return
+    end
+
+    local line = current_revealed_line()
+    if line then
+      clear_line_extmarks(bufnr, line - 1)
+      apply_revealed_highlight(bufnr, line - 1)
     end
   end)
 end
@@ -180,6 +227,10 @@ local function cleanup_reveal_hook()
   if revealed_state.hook_id then
     hooks.off('variable_detected', revealed_state.hook_id)
     revealed_state.hook_id = nil
+  end
+  if revealed_state.after_decorate_hook_id then
+    hooks.off('after_decorate', revealed_state.after_decorate_hook_id)
+    revealed_state.after_decorate_hook_id = nil
   end
 end
 

--- a/lua/camouflage/templates/project_config.yaml
+++ b/lua/camouflage/templates/project_config.yaml
@@ -105,8 +105,8 @@ patterns:
 #
 # Example:
 # custom_patterns:
-#   - file_pattern: '*.rest'
-#     pattern: '@([%w_]+)%s*=%s*(.+)'
+#   - file_pattern: '*.myconfig'
+#     pattern: '^%s*@([%w_]+)%s*=%s*(.+)'
 #     key_capture: 1
 #     value_capture: 2
 custom_patterns: []

--- a/lua/camouflage/treesitter.lua
+++ b/lua/camouflage/treesitter.lua
@@ -19,12 +19,27 @@ local fallback_queries = {
       key: (_) @key
       value: (flow_node
         [(plain_scalar) (double_quote_scalar) (single_quote_scalar)] @value))
+    (block_mapping_pair
+      key: (_) @key
+      value: (block_node
+        (block_scalar) @value))
     (flow_pair
       key: (flow_node) @key
       value: (flow_node
         [(plain_scalar) (double_quote_scalar) (single_quote_scalar)] @value))
   ]],
-  toml = '(pair key: (_) @key value: (_) @value)',
+  toml = [[
+    (pair
+      [(bare_key) (dotted_key) (quoted_key)] @key
+      [(string)
+       (integer)
+       (float)
+       (boolean)
+       (local_date)
+       (local_time)
+       (local_date_time)
+       (offset_date_time)] @value)
+  ]],
   xml = [[
     (element
       (STag (Name) @key)
@@ -268,6 +283,19 @@ local function first_child_of_type(node, node_type)
   return nil
 end
 
+---@param node userdata
+---@param node_types table<string, boolean>
+---@return userdata|nil
+local function first_child_of_types(node, node_types)
+  for i = 0, node:child_count() - 1 do
+    local child = node:child(i)
+    if child and node_types[child:type()] then
+      return child
+    end
+  end
+  return nil
+end
+
 ---@param pair userdata
 ---@param bufnr number
 ---@return string|nil
@@ -310,15 +338,61 @@ local function derive_pair_key_path(lang, key_node, bufnr)
   return table.concat(parts, '.'), #parts > 1
 end
 
+local toml_key_types = {
+  bare_key = true,
+  dotted_key = true,
+  quoted_key = true,
+}
+
+---@param table_node userdata
+---@param bufnr number
+---@return string|nil
+local function toml_table_key_text(table_node, bufnr)
+  local key_node = first_child_of_types(table_node, toml_key_types)
+  if not key_node then
+    return nil
+  end
+  return normalize_key_text(vim.treesitter.get_node_text(key_node, bufnr))
+end
+
+---@param key_node userdata
+---@param fallback_key string
+---@param bufnr number
+---@return string key_path
+---@return boolean is_nested
+local function derive_toml_key_path(key_node, fallback_key, bufnr)
+  local parts = {}
+  local node = key_node:parent()
+
+  while node do
+    local node_type = node:type()
+    if
+      node_type == 'table'
+      or node_type == 'table_array'
+      or node_type == 'array_table'
+      or node_type == 'table_array_element'
+    then
+      local key = toml_table_key_text(node, bufnr)
+      if key and key ~= '' then
+        table.insert(parts, 1, key)
+      end
+    end
+    node = node:parent()
+  end
+
+  table.insert(parts, fallback_key)
+  return table.concat(parts, '.'), #parts > 1 or fallback_key:find('%.') ~= nil
+end
+
 ---@param element userdata
 ---@param bufnr number
 ---@return string|nil
 local function xml_element_name(element, bufnr)
-  local stag = first_child_of_type(element, 'STag')
-  if not stag then
+  local tag = first_child_of_type(element, 'STag') or first_child_of_type(element, 'EmptyElemTag')
+  if not tag then
     return nil
   end
-  local name = first_child_of_type(stag, 'Name')
+  local name = first_child_of_type(tag, 'Name')
   if not name then
     return nil
   end
@@ -391,10 +465,52 @@ local function derive_key_path(lang, key_node, fallback_key, bufnr)
   local key_path, is_nested
   if lang == 'json' or lang == 'yaml' then
     key_path, is_nested = derive_pair_key_path(lang, key_node, bufnr)
+  elseif lang == 'toml' then
+    key_path, is_nested = derive_toml_key_path(key_node, fallback_key, bufnr)
   elseif lang == 'xml' then
     key_path, is_nested = derive_xml_key_path(key_node, fallback_key, bufnr)
   end
   return key_path or fallback_key, is_nested == true
+end
+
+---@param value string
+---@param start_index number
+---@param end_index number
+---@return string value
+---@return number start_index
+---@return number end_index
+local function normalize_toml_string(value, start_index, end_index)
+  if
+    (value:sub(1, 3) == '"""' and value:sub(-3) == '"""')
+    or (value:sub(1, 3) == "'''" and value:sub(-3) == "'''")
+  then
+    return value:sub(4, -4), start_index + 3, end_index - 3
+  end
+
+  local first = value:sub(1, 1)
+  if (first == '"' or first == "'") and value:sub(-1) == first then
+    return value:sub(2, -2), start_index + 1, end_index - 1
+  end
+
+  return value, start_index, end_index
+end
+
+---@param node_text string
+---@param start_row number
+---@param start_index number
+---@param offsets number[]
+---@return string value
+---@return number start_index
+---@return number end_index
+local function normalize_yaml_block_scalar(node_text, start_row, start_index, offsets)
+  local first_newline = node_text:find('\n', 1, true)
+  if not first_newline then
+    return '', start_index, start_index
+  end
+
+  local value = node_text:sub(first_newline + 1):gsub('%s+$', '')
+  local content_start = offsets[start_row + 2] or start_index + first_newline
+  return value, content_start, content_start + #value
 end
 
 ---Parse a buffer using TreeSitter and extract key-value pairs
@@ -453,8 +569,15 @@ function M.parse(bufnr, lang, content)
         local start_row, start_col, end_row, end_col = node:range()
 
         -- Byte offsets via the precomputed line table (node rows are 0-based).
-        local start_index = offsets[start_row + 1] + start_col
-        local end_index = offsets[end_row + 1] + end_col
+        local start_offset = offsets[start_row + 1]
+        local end_offset = offsets[end_row + 1] or #content
+        if not start_offset then
+          current_key = nil
+          current_key_text = nil
+          goto continue
+        end
+        local start_index = start_offset + start_col
+        local end_index = end_offset + end_col
 
         -- Get actual value (remove quotes for strings)
         local value = node_text
@@ -470,6 +593,11 @@ function M.parse(bufnr, lang, content)
           value = value:sub(2, -2)
           start_index = start_index + 1
           end_index = end_index - 1
+        elseif lang == 'yaml' and node_type == 'block_scalar' then
+          value, start_index, end_index =
+            normalize_yaml_block_scalar(node_text, start_row, start_index, offsets)
+        elseif lang == 'toml' and node_type == 'string' then
+          value, start_index, end_index = normalize_toml_string(value, start_index, end_index)
         elseif lang == 'xml' and node_type == 'AttValue' then
           -- XML attribute values include quotes: "value" or 'value'
           if value:match('^".*"$') or value:match("^'.*'$") then
@@ -490,6 +618,7 @@ function M.parse(bufnr, lang, content)
             line_number = start_row,
             is_nested = is_nested,
             is_commented = false,
+            is_multiline = end_row ~= start_row or nil,
           })
         end
       end
@@ -497,6 +626,8 @@ function M.parse(bufnr, lang, content)
       current_key = nil
       current_key_text = nil
     end
+
+    ::continue::
   end
 
   return variables

--- a/queries/toml/camouflage.scm
+++ b/queries/toml/camouflage.scm
@@ -1,5 +1,12 @@
 ; camouflage.nvim - TOML key-value pairs
 
 (pair
-  key: (_) @key
-  value: (_) @value)
+  [(bare_key) (dotted_key) (quoted_key)] @key
+  [(string)
+   (integer)
+   (float)
+   (boolean)
+   (local_date)
+   (local_time)
+   (local_date_time)
+   (offset_date_time)] @value)

--- a/queries/yaml/camouflage.scm
+++ b/queries/yaml/camouflage.scm
@@ -6,6 +6,11 @@
   value: (flow_node
     [(plain_scalar) (double_quote_scalar) (single_quote_scalar)] @value))
 
+(block_mapping_pair
+  key: (_) @key
+  value: (block_node
+    (block_scalar) @value))
+
 (flow_pair
   key: (flow_node) @key
   value: (flow_node

--- a/tests/camouflage/follow_cursor_spec.lua
+++ b/tests/camouflage/follow_cursor_spec.lua
@@ -23,6 +23,15 @@ describe('camouflage.reveal follow_cursor', function()
     return bufnr
   end
 
+  local function setup_yaml_test_buffer(content)
+    test_counter = test_counter + 1
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(content, '\n'))
+    vim.api.nvim_buf_set_name(bufnr, '/tmp/test_follow_' .. test_counter .. '.yaml')
+    vim.api.nvim_set_current_buf(bufnr)
+    return bufnr
+  end
+
   local function follow_cursor_autocmd_count()
     return #vim.api.nvim_get_autocmds({
       group = state.runtime_augroup,
@@ -255,6 +264,45 @@ describe('camouflage.reveal follow_cursor', function()
 
       assert.is_true(reveal.is_revealed())
       assert.equals(1, reveal.get_revealed().line)
+    end)
+
+    it('follows multiline value content lines', function()
+      local content = table.concat({
+        'private_key: |',
+        '  line-one',
+        '  line-two',
+        'NEXT=value',
+      }, '\n')
+      local bufnr = setup_yaml_test_buffer(content)
+      local start_index = content:find('  line-one', 1, true) - 1
+      local value = '  line-one\n  line-two'
+      state.set_variables(bufnr, {
+        {
+          key = 'private_key',
+          value = value,
+          start_index = start_index,
+          end_index = start_index + #value,
+          line_number = 0,
+          is_multiline = true,
+        },
+      })
+
+      vim.api.nvim_win_set_cursor(0, { 2, 2 })
+      reveal.start_follow_cursor()
+
+      assert.is_true(reveal.is_revealed())
+      assert.equals(2, reveal.get_revealed().line)
+
+      vim.api.nvim_win_set_cursor(0, { 3, 2 })
+      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
+
+      assert.is_true(reveal.is_revealed())
+      assert.equals(3, reveal.get_revealed().line)
+
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      vim.api.nvim_exec_autocmds('CursorMoved', { buffer = bufnr })
+
+      assert.is_false(reveal.is_revealed())
     end)
   end)
 

--- a/tests/camouflage/parsers/xml_spec.lua
+++ b/tests/camouflage/parsers/xml_spec.lua
@@ -72,9 +72,9 @@ describe('camouflage.parsers.xml', function()
         keys[v.key] = v.value
       end
 
-      assert.equals('localhost', keys['host'])
-      assert.equals('dbpass', keys['password'])
-      assert.equals('5432', keys['port'])
+      assert.equals('localhost', keys['database@host'])
+      assert.equals('dbpass', keys['database@password'])
+      assert.equals('5432', keys['database@port'])
     end)
 
     it('should parse single-quoted attributes', function()
@@ -86,8 +86,8 @@ describe('camouflage.parsers.xml', function()
         keys[v.key] = v.value
       end
 
-      assert.equals('localhost', keys['host'])
-      assert.equals('secret', keys['password'])
+      assert.equals('localhost', keys['server@host'])
+      assert.equals('secret', keys['server@password'])
     end)
 
     it('should parse mixed elements and attributes', function()
@@ -106,8 +106,8 @@ describe('camouflage.parsers.xml', function()
         keys[v.key] = v.value
       end
 
-      assert.equals('localhost', keys['host'])
-      assert.equals('dbpass', keys['password'])
+      assert.equals('localhost', keys['settings.database@host'])
+      assert.equals('dbpass', keys['settings.database@password'])
       assert.equals('api-secret-key', keys['settings.api.key'])
     end)
 
@@ -207,6 +207,27 @@ describe('camouflage.parsers.xml', function()
       assert.equals(2, #passwords)
     end)
 
+    it('should keep namespace root elements in key paths', function()
+      local content = [[
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+  <servers>
+    <server>
+      <password>deploy123</password>
+    </server>
+  </servers>
+</settings>
+]]
+      local result = xml_parser.parse_regex(content)
+
+      local keys = {}
+      for _, v in ipairs(result) do
+        keys[v.key] = v.value
+      end
+
+      assert.equals('deploy123', keys['settings.servers.server.password'])
+    end)
+
     it('should parse pom.xml style structure', function()
       local content = [[
 <project>
@@ -249,8 +270,8 @@ describe('camouflage.parsers.xml', function()
         keys[v.key] = v.value
       end
 
-      assert.equals('localhost', keys['host'])
-      assert.equals('5432', keys['port'])
+      assert.equals('localhost', keys['config.database@host'])
+      assert.equals('5432', keys['config.database@port'])
       assert.equals('secret', keys['config.password'])
     end)
 
@@ -272,7 +293,7 @@ describe('camouflage.parsers.xml', function()
         keys[v.key] = v.value
       end
 
-      assert.equals('secret', keys['sec:password'])
+      assert.equals('secret', keys['server@sec:password'])
     end)
 
     it('should set correct line numbers', function()
@@ -337,8 +358,8 @@ describe('camouflage.parsers.xml', function()
         values[v.key] = v.value
         assert.equals(v.value, content:sub(v.start_index + 1, v.end_index))
       end
-      assert.equals("it's", values['token'])
-      assert.equals('say "hi"', values['other'])
+      assert.equals("it's", values['a@token'])
+      assert.equals('say "hi"', values['a@other'])
     end)
   end)
 end)

--- a/tests/camouflage/reveal_spec.lua
+++ b/tests/camouflage/reveal_spec.lua
@@ -2,6 +2,7 @@ describe('camouflage.reveal', function()
   local reveal
   local state
   local hooks
+  local core
   local test_counter = 0
 
   local function clear_camouflage_modules()
@@ -24,6 +25,15 @@ describe('camouflage.reveal', function()
     return bufnr
   end
 
+  local function setup_yaml_test_buffer(content)
+    test_counter = test_counter + 1
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, vim.split(content, '\n'))
+    vim.api.nvim_buf_set_name(bufnr, '/tmp/test_reveal_' .. test_counter .. '.yaml')
+    vim.api.nvim_set_current_buf(bufnr)
+    return bufnr
+  end
+
   before_each(function()
     clear_camouflage_modules()
     require('camouflage').setup({
@@ -34,6 +44,7 @@ describe('camouflage.reveal', function()
     reveal = require('camouflage.reveal')
     state = require('camouflage.state')
     hooks = require('camouflage.hooks')
+    core = require('camouflage.core')
   end)
 
   after_each(function()
@@ -58,6 +69,98 @@ describe('camouflage.reveal', function()
       local revealed = reveal.get_revealed()
       assert.equals(bufnr, revealed.bufnr)
       assert.equals(1, revealed.line)
+    end)
+
+    it('reveals a multiline value content line', function()
+      local content = table.concat({
+        'private_key: |',
+        '  line-one',
+        '  line-two',
+        'NEXT=value',
+      }, '\n')
+      local bufnr = setup_yaml_test_buffer(content)
+      local start_index = content:find('  line-one', 1, true) - 1
+      local value = '  line-one\n  line-two'
+      state.set_variables(bufnr, {
+        {
+          key = 'private_key',
+          value = value,
+          start_index = start_index,
+          end_index = start_index + #value,
+          line_number = 0,
+          is_multiline = true,
+        },
+      })
+
+      vim.api.nvim_win_set_cursor(0, { 2, 2 })
+      reveal.reveal_line()
+
+      assert.is_true(reveal.is_revealed())
+      assert.equals(2, reveal.get_revealed().line)
+    end)
+
+    it('does not reveal a multiline declaration line without value bytes', function()
+      local content = table.concat({
+        'private_key: |',
+        '  line-one',
+        '  line-two',
+      }, '\n')
+      local bufnr = setup_yaml_test_buffer(content)
+      local start_index = content:find('  line-one', 1, true) - 1
+      local value = '  line-one\n  line-two'
+      state.set_variables(bufnr, {
+        {
+          key = 'private_key',
+          value = value,
+          start_index = start_index,
+          end_index = start_index + #value,
+          line_number = 0,
+          is_multiline = true,
+        },
+      })
+
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      reveal.reveal_line()
+
+      assert.is_false(reveal.is_revealed())
+    end)
+
+    it('keeps the revealed multiline row revealed after redecoration', function()
+      local content = table.concat({
+        'private_key: |',
+        '  line-one',
+        '  line-two',
+      }, '\n')
+      local bufnr = setup_yaml_test_buffer(content)
+      vim.bo[bufnr].filetype = 'yaml'
+      core.apply_decorations(bufnr)
+
+      vim.api.nvim_win_set_cursor(0, { 2, 2 })
+      reveal.reveal_line()
+      core.apply_decorations(bufnr)
+
+      assert.is_true(reveal.is_revealed())
+      assert.equals(2, reveal.get_revealed().line)
+
+      local marks = vim.api.nvim_buf_get_extmarks(bufnr, state.namespace, 0, -1, {
+        details = true,
+      })
+      local revealed_rows = {}
+      local masked_rows = {}
+      for _, mark in ipairs(marks) do
+        local row = mark[2] + 1
+        local details = mark[4]
+        if details.hl_group == 'CamouflageRevealed' then
+          revealed_rows[row] = true
+        end
+        if details.virt_text then
+          masked_rows[row] = true
+        end
+      end
+
+      assert.is_true(revealed_rows[2])
+      assert.is_nil(masked_rows[2])
+      assert.is_true(masked_rows[3])
     end)
 
     it('does nothing if already revealed on same line', function()

--- a/tests/camouflage/treesitter_queries_spec.lua
+++ b/tests/camouflage/treesitter_queries_spec.lua
@@ -14,6 +14,12 @@ describe('camouflage.treesitter queries', function()
       it('should have query available for ' .. lang, function()
         -- Query should be available either from file or fallback
         local ok, query = pcall(vim.treesitter.query.get, lang, 'camouflage')
+        if treesitter.has_parser(lang) then
+          assert.is_true(ok, 'query should parse for installed parser: ' .. lang)
+          assert.is_not_nil(query, 'query should load for installed parser: ' .. lang)
+          return
+        end
+
         if not ok or not query then
           -- Check fallback exists
           local fallback_ok = pcall(vim.treesitter.query.parse, lang, '(_) @test')
@@ -47,6 +53,21 @@ describe('camouflage.treesitter queries', function()
       end
 
       local query = vim.treesitter.query.get('yaml', 'camouflage')
+      if query then
+        local has_key = vim.tbl_contains(query.captures, 'key')
+        local has_value = vim.tbl_contains(query.captures, 'value')
+        assert.is_true(has_key, 'should have @key capture')
+        assert.is_true(has_value, 'should have @value capture')
+      end
+    end)
+
+    it('should have @key and @value captures for toml', function()
+      if not treesitter.has_parser('toml') then
+        pending('toml parser not available')
+        return
+      end
+
+      local query = vim.treesitter.query.get('toml', 'camouflage')
       if query then
         local has_key = vim.tbl_contains(query.captures, 'key')
         local has_value = vim.tbl_contains(query.captures, 'value')

--- a/tests/camouflage/treesitter_spec.lua
+++ b/tests/camouflage/treesitter_spec.lua
@@ -94,6 +94,7 @@ describe('camouflage.treesitter', function()
   describe('parse with treesitter (integration)', function()
     local json_parser_available = ts.has_parser('json')
     local yaml_parser_available = ts.has_parser('yaml')
+    local toml_parser_available = ts.has_parser('toml')
     local xml_parser_available = ts.has_parser('xml')
 
     if json_parser_available then
@@ -231,6 +232,42 @@ describe('camouflage.treesitter', function()
         end
       end)
 
+      it('should parse YAML block scalars as multiline values', function()
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local lines = {
+          'certificates:',
+          '  private_key: |',
+          '    -----BEGIN RSA PRIVATE KEY-----',
+          '    secret-key-material',
+          '  certificate: >',
+          '    folded certificate',
+          '    material',
+        }
+        local content = table.concat(lines, '\n')
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+        vim.api.nvim_set_option_value('filetype', 'yaml', { buf = bufnr })
+
+        local result = ts.parse(bufnr, 'yaml', content)
+
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+
+        if result then
+          local by_key = {}
+          for _, v in ipairs(result) do
+            by_key[v.key] = v
+            assert.equals(v.value, content:sub(v.start_index + 1, v.end_index))
+          end
+          assert.is_not_nil(by_key['certificates.private_key'])
+          assert.is_true(by_key['certificates.private_key'].is_multiline)
+          assert.is_true(by_key['certificates.private_key'].value:match('BEGIN RSA') ~= nil)
+          assert.is_not_nil(by_key['certificates.certificate'])
+          assert.is_true(by_key['certificates.certificate'].is_multiline)
+          assert.is_true(
+            by_key['certificates.certificate'].value:match('folded certificate') ~= nil
+          )
+        end
+      end)
+
       it('should skip YAML flow mapping containers', function()
         local bufnr = vim.api.nvim_create_buf(false, true)
         local content = 'outer: {inner: value}'
@@ -247,6 +284,37 @@ describe('camouflage.treesitter', function()
           assert.equals(1, #result)
           assert.equals('outer.inner', result[1].key)
           assert.equals('value', result[1].value)
+        end
+      end)
+    end
+
+    if toml_parser_available then
+      it('should expose TOML table key paths and unquoted string values', function()
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local lines = {
+          '[database]',
+          'host = "localhost"',
+          'password = "secret"',
+          'port = 5432',
+        }
+        local content = table.concat(lines, '\n')
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+        vim.api.nvim_set_option_value('filetype', 'toml', { buf = bufnr })
+
+        local result = ts.parse(bufnr, 'toml', content)
+
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+
+        if result then
+          local by_key = {}
+          for _, v in ipairs(result) do
+            by_key[v.key] = v
+            assert.equals(v.value, content:sub(v.start_index + 1, v.end_index))
+          end
+          assert.equals('localhost', by_key['database.host'].value)
+          assert.equals('secret', by_key['database.password'].value)
+          assert.equals('5432', by_key['database.port'].value)
+          assert.is_true(by_key['database.password'].is_nested)
         end
       end)
     end
@@ -274,6 +342,27 @@ describe('camouflage.treesitter', function()
           assert.equals('secret', by_key['settings.database.password'].value)
           assert.is_true(by_key['settings.database@password'].is_nested)
           assert.is_true(by_key['settings.database.password'].is_nested)
+        end
+      end)
+
+      it('should include self-closing XML element names in attribute key paths', function()
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local content = '<settings><database host="localhost" password="dbpass"/></settings>'
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { content })
+        vim.api.nvim_set_option_value('filetype', 'xml', { buf = bufnr })
+
+        local result = ts.parse(bufnr, 'xml', content)
+
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+
+        if result then
+          local by_key = {}
+          for _, v in ipairs(result) do
+            by_key[v.key] = v
+            assert.equals(v.value, content:sub(v.start_index + 1, v.end_index))
+          end
+          assert.equals('localhost', by_key['settings.database@host'].value)
+          assert.equals('dbpass', by_key['settings.database@password'].value)
         end
       end)
     end


### PR DESCRIPTION
## Description

Fixes masking gaps around multiline values and structured parser ranges.

- Parse YAML block scalars through TreeSitter and normalize their value ranges to the actual content bytes.
- Improve TOML TreeSitter coverage for scalar values, quoted strings, and table-qualified key paths.
- Preserve XML element paths for attributes, including self-closing tags and namespace-style attributes, so attribute keys stay distinct from child elements.
- Make reveal and follow-cursor checks range-based, so multiline value content lines can be revealed while declaration/marker lines stay masked.
- Document opt-in custom patterns for unsupported formats and use an anchored `*.myconfig` example.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

## Verification

- `make format`
- `make test`
- `make check`
- `git diff --check`
- Headless fixture check confirmed YAML multiline content lines reveal correctly, while the block scalar marker line does not reveal.

## Screenshots

N/A
