### PR TITLE
feat(json): add native JSONC (*.jsonc) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Hide sensitive values in configuration files during screen sharing.
 
-A Neovim plugin that visually masks secrets in `.env`, `.json`, `.yaml`, `.toml`, `.properties`, `.netrc`, `.xml`, `.http`, **Terraform/HCL** (`.tf`, `.tfvars`, `.hcl`), and **Dockerfile** files using extmarks - **without modifying the actual file content**.
+A Neovim plugin that visually masks secrets in `.env`, `.json`, `.jsonc`, `.yaml`, `.toml`, `.properties`, `.netrc`, `.xml`, `.http`, **Terraform/HCL** (`.tf`, `.tfvars`, `.hcl`), and **Dockerfile** files using extmarks - **without modifying the actual file content**.
 
 [![Version](https://img.shields.io/github/v/release/zeybek/camouflage.nvim?style=flat&color=yellow)](https://github.com/zeybek/camouflage.nvim/releases)
 [![CI](https://github.com/zeybek/camouflage.nvim/actions/workflows/ci.yml/badge.svg)](https://github.com/zeybek/camouflage.nvim/actions/workflows/ci.yml)
@@ -16,7 +16,7 @@ A Neovim plugin that visually masks secrets in `.env`, `.json`, `.yaml`, `.toml`
 
 ## Features
 
-- **Multi-format support**: `.env`, `.json`, `.yaml`, `.yml`, `.toml`, `.properties`, `.ini`, `.conf`, `.sh`, `.netrc`, `.xml`, `.http`, `.tf`, `.tfvars`, `.hcl`, `Dockerfile`, `Containerfile`
+- **Multi-format support**: `.env`, `.json`, `.jsonc`, `.yaml`, `.yml`, `.toml`, `.properties`, `.ini`, `.conf`, `.sh`, `.netrc`, `.xml`, `.http`, `.tf`, `.tfvars`, `.hcl`, `Dockerfile`, `Containerfile`
 - **Nested key support**: Handles `database.connection.password` in JSON/YAML/XML
 - **All value types**: Masks strings, numbers, and booleans
 - **Multiple styles**: `stars`, `dotted`, `text`, `scramble`
@@ -343,7 +343,7 @@ With `debug = true`, custom check logs include check names, run counts, failures
 | Format | Extensions | Nested Keys |
 |--------|-----------|-------------|
 | Environment | `.env`, `.env.*`, `.envrc`, `.sh` | No |
-| JSON | `.json` | Yes |
+| JSON | `.json`, `.jsonc` | Yes |
 | YAML | `.yaml`, `.yml` | Yes |
 | TOML | `.toml` | Yes (sections) |
 | Properties | `.properties`, `.ini`, `.conf`, `credentials` | Yes (sections) |

--- a/doc/camouflage.txt
+++ b/doc/camouflage.txt
@@ -38,8 +38,8 @@ configuration files during screen sharing. It uses extmarks to overlay
 masked text without modifying the actual file content.
 
 Features:
-- Multi-format support: .env, .json, .yaml, .toml, .properties, .netrc, .xml,
-  .http, .tf, .tfvars, .hcl, Dockerfile, Containerfile
+- Multi-format support: .env, .json, .jsonc, .yaml, .toml, .properties, .netrc,
+  .xml, .http, .tf, .tfvars, .hcl, Dockerfile, Containerfile
 - Nested key support for JSON, YAML, and XML
 - Multiple masking styles: stars, dotted, text, scramble
 - Have I Been Pwned integration for password breach checking
@@ -877,7 +877,8 @@ Environment files ~
 <
 
 JSON files ~
-  Extensions: .json
+  Extensions: .json, .jsonc
+  JSONC (JSON with comments and trailing commas) is handled by the same parser.
   Supports nested keys like `database.connection.password`
   Example: >json
     {

--- a/lua/camouflage/config.lua
+++ b/lua/camouflage/config.lua
@@ -211,7 +211,7 @@ M.defaults = {
   patterns = {
     { file_pattern = { '.env*', '*.env', '.envrc' }, parser = 'env' },
     { file_pattern = { '*.sh' }, parser = 'env' },
-    { file_pattern = { '*.json' }, parser = 'json' },
+    { file_pattern = { '*.json', '*.jsonc' }, parser = 'json' },
     { file_pattern = { '*.yaml', '*.yml' }, parser = 'yaml' },
     { file_pattern = { '*.toml' }, parser = 'toml' },
     { file_pattern = { '*.properties', '*.ini', '*.conf', 'credentials' }, parser = 'properties' },

--- a/lua/camouflage/parsers/json.lua
+++ b/lua/camouflage/parsers/json.lua
@@ -448,7 +448,7 @@ function M.get_line_number(content, index)
 end
 
 M.filetypes = { 'json', 'jsonc' }
-M.file_patterns = { '*.json' }
+M.file_patterns = { '*.json', '*.jsonc' }
 M.treesitter = { lang = 'json' }
 
 return M

--- a/lua/camouflage/templates/project_config.yaml
+++ b/lua/camouflage/templates/project_config.yaml
@@ -77,7 +77,7 @@ patterns:
     parser: env
   - file_pattern: ['*.sh']
     parser: env
-  - file_pattern: ['*.json']
+  - file_pattern: ['*.json', '*.jsonc']
     parser: json
   - file_pattern: ['*.yaml', '*.yml']
     parser: yaml

--- a/tests/camouflage/parsers/init_spec.lua
+++ b/tests/camouflage/parsers/init_spec.lua
@@ -97,6 +97,13 @@ describe('camouflage.parsers', function()
       assert.equals('json', name)
     end)
 
+    it('should return json parser for settings.jsonc', function()
+      local parser, name = parsers.find_parser_for_file('settings.jsonc')
+
+      assert.is_not_nil(parser)
+      assert.equals('json', name)
+    end)
+
     it('should return yaml parser for config.yaml', function()
       local parser, name = parsers.find_parser_for_file('config.yaml')
 
@@ -176,6 +183,10 @@ describe('camouflage.parsers', function()
 
     it('should return true for config.json', function()
       assert.is_true(parsers.is_supported('config.json'))
+    end)
+
+    it('should return true for settings.jsonc', function()
+      assert.is_true(parsers.is_supported('settings.jsonc'))
     end)
 
     it('should return true for settings.yaml', function()

--- a/tests/camouflage/parsers/json_spec.lua
+++ b/tests/camouflage/parsers/json_spec.lua
@@ -180,6 +180,25 @@ describe('camouflage.parsers.json', function()
       assert.equals(0, #result)
     end)
 
+    it('should mask JSONC values with comments and trailing commas', function()
+      local content = [[{
+  // editor settings
+  "editor.fontSize": 14,
+  "github.token": "ghp_secret", // trailing comment
+  "trailing": "comma",
+}]]
+      local result = json_parser.parse(content)
+
+      local by_key = {}
+      for _, var in ipairs(result) do
+        by_key[var.key] = var.value
+      end
+
+      assert.equals('ghp_secret', by_key['github.token'])
+      assert.equals('comma', by_key['trailing'])
+      assert.is_nil(by_key['// editor settings'])
+    end)
+
     it('should use the pattern fallback for invalid JSON with string pairs', function()
       local result = json_parser.parse('{"api_key": "secret", invalid')
 

--- a/tests/camouflage/treesitter_queries_spec.lua
+++ b/tests/camouflage/treesitter_queries_spec.lua
@@ -99,5 +99,43 @@ describe('camouflage.treesitter queries', function()
         assert.equals('secret123', result[1].value)
       end
     end)
+
+    it('should parse jsonc comments and trailing commas with the json grammar', function()
+      if not treesitter.has_parser('json') then
+        pending('json parser not available')
+        return
+      end
+
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local lines = {
+        '{',
+        '  // editor settings',
+        '  "editor.fontSize": 14,',
+        '  /* "commented": "ignored" */',
+        '  "github.token": "ghp_secret", // trailing comment',
+        '  "db": {',
+        '    "password": "hunter2",',
+        '  },',
+        '}',
+      }
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+      vim.api.nvim_buf_set_option(bufnr, 'filetype', 'jsonc')
+      local content = table.concat(lines, '\n')
+
+      local result = treesitter.parse(bufnr, 'json', content)
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+
+      if result then
+        local by_key = {}
+        for _, var in ipairs(result) do
+          by_key[var.key] = var.value
+        end
+        assert.equals('14', by_key['editor.fontSize'])
+        assert.equals('ghp_secret', by_key['github.token'])
+        assert.equals('hunter2', by_key['db.password'])
+        assert.is_nil(by_key['commented'])
+      end
+    end)
   end)
 end)


### PR DESCRIPTION
## Description

Adds native support for JSONC (`*.jsonc`) files by registering the existing JSON parser for the `*.jsonc` file pattern.

- `lua/camouflage/config.lua`: default `patterns` now maps `*.jsonc` to the `json` parser
- `lua/camouflage/parsers/json.lua`: `file_patterns` includes `*.jsonc` (the module already listed `jsonc` in `filetypes`, but parser lookup only consults file patterns, so that hint never applied)
- `lua/camouflage/templates/project_config.yaml`: `:CamouflageInit` template mirrors the new default
- `README.md`, `doc/camouflage.txt`: format lists and the supported-formats table mention `.jsonc`

No parser changes were needed. The TreeSitter path already parses the buffer with the `json` grammar explicitly, which tolerates `//` and `/* */` comments and trailing commas, so nested keys such as `db.password` are captured correctly. Verified end to end on a VS Code style `settings.jsonc` with comments and trailing commas: 5 values masked, comment contents untouched.

Tests added:

- `parsers/init_spec.lua`: `find_parser_for_file` and `is_supported` resolve `settings.jsonc` to the `json` parser
- `parsers/json_spec.lua`: JSONC content with comments and trailing commas is parsed without error and comment lines are not treated as keys
- `treesitter_queries_spec.lua`: JSONC buffer parsed through the `json` grammar yields the right nested keys and skips values inside block comments

## Related Issue

Closes #47

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and `make format`
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`make test`)
- [x] I have updated the documentation if needed
- [x] My commit messages follow conventional commits format

## Screenshots (if applicable)

N/A
